### PR TITLE
Support PROJECT_CREATION_UPLOAD

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
@@ -186,6 +186,11 @@ public class DependencyTrackPublisher extends Recorder implements SimpleBuildSte
     private boolean upload(TaskListener listener, String projectId, String projectName, String projectVersion, String artifact, boolean isScanResult, FilePath workspace) throws IOException {
         final FilePath filePath = new FilePath(workspace, artifact);
         final String encodedScan;
+        if (projectId == null && (projectName == null || projectVersion == null)) {
+            log(Messages.Builder_Result_InvalidArguments());
+            return false;
+        }
+
         try {
             if (StringUtils.isBlank(artifact) || !filePath.exists()) {
                 log(Messages.Builder_Result_NonExist());

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.jelly
@@ -18,13 +18,13 @@ limitations under the License.
 
     <f:section title="Dependency-Track">
 
-        <f:entry title="${%dependencytrack.url}" field="dependencyTrackUrl" help="/plugin/dependency-check-jenkins-plugin/help-dt-url.html">
+        <f:entry title="${%dependencytrack.url}" field="dependencyTrackUrl" help="/plugin/dependency-track/help-dt-url.html">
             <f:textbox id="dependencytrack.url"/>
         </f:entry>
-        <f:entry title="${%dependencytrack.apikey}" field="dependencyTrackApiKey" help="/plugin/dependency-check-jenkins-plugin/help-dt-apikey.html">
+        <f:entry title="${%dependencytrack.apikey}" field="dependencyTrackApiKey" help="/plugin/dependency-track/help-dt-apikey.html">
             <f:textbox id="dependencytrack.apikey"/>
         </f:entry>
-        <f:entry title="${%dependencytrack.autocreate}" field="dependencyTrackAutoCreateProjects" help="/plugin/dependency-check-jenkins-plugin/help-dt-autocreate.html">
+        <f:entry title="${%dependencytrack.autocreate}" field="dependencyTrackAutoCreateProjects" help="/plugin/dependency-track/help-dt-autocreate.html">
             <f:checkbox id="dependencytrack.autocreate" default="false"/>
         </f:entry>        
 

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.jelly
@@ -18,12 +18,15 @@ limitations under the License.
 
     <f:section title="Dependency-Track">
 
-        <f:entry title="${%dependencytrack.url}" field="dependencyTrackUrl" help="/plugin/dependency-track/help-dt-url.html">
+        <f:entry title="${%dependencytrack.url}" field="dependencyTrackUrl" help="/plugin/dependency-check-jenkins-plugin/help-dt-url.html">
             <f:textbox id="dependencytrack.url"/>
         </f:entry>
-        <f:entry title="${%dependencytrack.apikey}" field="dependencyTrackApiKey" help="/plugin/dependency-track/help-dt-apikey.html">
+        <f:entry title="${%dependencytrack.apikey}" field="dependencyTrackApiKey" help="/plugin/dependency-check-jenkins-plugin/help-dt-apikey.html">
             <f:textbox id="dependencytrack.apikey"/>
         </f:entry>
+        <f:entry title="${%dependencytrack.autocreate}" field="dependencyTrackAutoCreateProjects" help="/plugin/dependency-check-jenkins-plugin/help-dt-autocreate.html">
+            <f:checkbox id="dependencytrack.autocreate" default="false"/>
+        </f:entry>        
 
     </f:section>
 

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.properties
@@ -14,4 +14,4 @@
 
 dependencytrack.url=Dependency-Track URL
 dependencytrack.apikey=API key
-dependencytrack.autocreate=autoCreate
+dependencytrack.autocreate=Auto Create Projects

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.properties
@@ -14,3 +14,4 @@
 
 dependencytrack.url=Dependency-Track URL
 dependencytrack.apikey=API key
+dependencytrack.autocreate=autoCreate

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages.properties
@@ -16,6 +16,7 @@ Publisher.DependencyTrack.Name=Publish results to Dependency-Track
 
 Builder.Publishing=Publishing artifact to Dependency-Track
 Builder.Result.NonExist=The specified artifact does not exist
+Builder.Result.InvalidArguments=Either the projectId or the projectName and projectVersion have to be specified
 Builder.Error.Connect=Could not connect to Dependency-Track. Received response code
 Builder.Error.Projects=Unable to retrieve projects. Received status code
 Builder.Error.Processing=An error occurred processing artifact

--- a/src/main/webapp/help-dt-autocreate.html
+++ b/src/main/webapp/help-dt-autocreate.html
@@ -1,0 +1,3 @@
+<div>
+    Enable auto creation of projects when authentication is enabled on Dependency-Track and the API key provided has the PROJECT_CREATION_UPLOAD permission.
+</div>


### PR DESCRIPTION
# Description 

Allows the plugin to make use of the PROJECT_CREATION_UPLOAD permission when enabled in the global configuration. Feature only supported as a Pipeline build step.

# Testing 

The following Jenkins pipelines were used to test the feature:

## Using projectId

```
pipeline {
    agent {
        label 'master'
    }
    stages {
        stage ("TEST") {
            steps {
                dependencyTrackPublisher projectId: '701990d3-1320-4e10-b327-94dcf8be3367', artifact: 'dependency-check-report.xml', artifactType: 'scanResult'
            }
        }
    }
}
```

```
Started by user admin
Running in Durability level: MAX_SURVIVABILITY
[Pipeline] node
Running on Jenkins in /var/jenkins_home/workspace/test
[Pipeline] {
[Pipeline] stage
[Pipeline] { (TEST)
[Pipeline] dependencyTrackPublisher
[DependencyTrack] Publishing artifact to Dependency-Track
[DependencyTrack] The artifact was successfully published
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: SUCCESS
```

## Using projectName and projectVersion

```
pipeline {
    agent {
        label 'master'
    }
    stages {
        stage ("TEST") {
            steps {
                dependencyTrackPublisher projectName: 'autocreate', projectVersion: '0.0.1',  artifact: 'dependency-check-report.xml', artifactType: 'scanResult'
            }
        }
    }
}
```

```
Started by user admin
Running in Durability level: MAX_SURVIVABILITY
[Pipeline] node
Running on Jenkins in /var/jenkins_home/workspace/test
[Pipeline] {
[Pipeline] stage
[Pipeline] { (TEST)
[Pipeline] dependencyTrackPublisher
[DependencyTrack] Publishing artifact to Dependency-Track
[DependencyTrack] The artifact was successfully published
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: SUCCESS
```

