### PR TITLE
Bumped structs version to 1.20.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.10</version>
+            <version>1.20</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>


### PR DESCRIPTION
Structs 1.10 was causing my Jenkins instance to crash when installing dependency track.  It was complaining that 1.10 was too old and suggested moving to 1.17.  I tried both  structs 1.17 and 1.20 and both fixed my issue.  I've updated the pom to version 1.20 since it is the latests.  The test suite passes.