### PR TITLE
BugFix: Publish-Bom fails on Sync=true and projectName & projectVersion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.classpath
+.project
+.settings/
 /.idea/
 /target/
 /work/

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
@@ -219,7 +219,12 @@ public class DependencyTrackPublisher extends ThresholdCapablePublisher implemen
                     logger.log(Messages.Builder_Polling());
                 }
                 logger.log(Messages.Builder_Findings_Processing());
-                final String jsonResponseBody = apiClient.getFindings(this.projectId);
+                String jsonResponseBody = null;
+                if (null == this.projectId) {
+                	jsonResponseBody = apiClient.getFindings(this.projectName, this.projectVersion);
+                } else {
+                	jsonResponseBody = apiClient.getFindings(this.projectId); 
+                }
                 final FindingParser parser = new FindingParser(build.getNumber(), jsonResponseBody).parse();
                 final ArrayList<Finding> findings = parser.getFindings();
                 final SeverityDistribution severityDistribution = parser.getSeverityDistribution();


### PR DESCRIPTION
There is a bug in the plug-in, Please see below scenario:

Within pipeline option dependencyTrackPublisher, if you enable synchronous: true and provide projectName and projectVersion instead of projectId. Build fails with 500 Internal Server Error from dependency track API.

`dependencyTrackPublisher artifact: 'target/bom.xml', artifactType: 'bom', projectName: 'SomeNewProjectABC', synchronous: true, projectVersion: '1.0'`

Fixed the same by getting the projectId and then using the existing method for getting findings. Please note that I have used search API to get projectId from name and version as no direct API was available.

Feel free to start a discussion in case you are not satisfied with bug scenario or quality of the pull request.