### PR TITLE
Fetch project uuid after auto-creation.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/ApiClient.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/ApiClient.java
@@ -43,6 +43,9 @@ public class ApiClient {
     private static final String BOM_TOKEN_URL = "/api/v1/bom/token";
     private static final String BOM_UPLOAD_URL = "/api/v1/bom";
     private static final String SCAN_UPLOAD_URL = "/api/v1/scan";
+    private static final String PROJECT_LOOKUP_URL = "/api/v1/project/lookup";
+    private static final String PROJECT_LOOKUP_NAME_PARAM = "name";
+    private static final String PROJECT_LOOKUP_VERSION_PARAM = "version";
 
     private final String baseUrl;
     private final String apiKey;
@@ -52,6 +55,28 @@ public class ApiClient {
         this.baseUrl = baseUrl;
         this.apiKey = apiKey;
         this.logger = logger;
+    }
+
+    public String lookupProject(String projectName, String projectVersion) throws ApiClientException {
+        try {
+            final HttpURLConnection conn = (HttpURLConnection) new URL(baseUrl + PROJECT_LOOKUP_URL + "?"
+                    + PROJECT_LOOKUP_NAME_PARAM + "=" + projectName + "&"
+                    + PROJECT_LOOKUP_VERSION_PARAM + "=" + projectVersion)
+                    .openConnection();
+            conn.setDoOutput(true);
+            conn.setDoInput(true);
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty(API_KEY_HEADER, apiKey);
+            conn.connect();
+            // Checks the server response
+            if (conn.getResponseCode() == 200) {
+                return getResponseBody(conn.getInputStream());
+            } else {
+                throw new ApiClientException("An error occurred while looking up project id - HTTP response code: " + conn.getResponseCode() + " " + conn.getResponseMessage());
+            }
+        } catch (IOException e) {
+            throw new ApiClientException("An error occurred while looking up project id", e);
+        }
     }
 
     public String getFindings(String projectUuid) throws ApiClientException {

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
@@ -218,6 +218,12 @@ public class DependencyTrackPublisher extends ThresholdCapablePublisher implemen
                     }
                     logger.log(Messages.Builder_Polling());
                 }
+                if (this.projectId == null) {
+                    // project was auto-created. Fetch it's new uuid so that we can look up the results
+                    logger.log(Messages.Builder_Project_Lookup());
+                    final String jsonResponseBody = apiClient.lookupProject(this.projectName, this.projectVersion);
+                    this.projectId = new ProjectLookupParser(jsonResponseBody).parse().getProject().getUuid();
+                }
                 logger.log(Messages.Builder_Findings_Processing());
                 final String jsonResponseBody = apiClient.getFindings(this.projectId);
                 final FindingParser parser = new FindingParser(build.getNumber(), jsonResponseBody).parse();

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/ProjectLookupParser.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/ProjectLookupParser.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Dependency-Track Jenkins plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jenkinsci.plugins.DependencyTrack;
+
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.DependencyTrack.model.Project;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ProjectLookupParser {
+
+    private final String jsonResponse;
+
+    private Project project;
+
+    public ProjectLookupParser(String jsonResponse) {
+        this.jsonResponse = jsonResponse;
+    }
+
+    public ProjectLookupParser parse() {
+        this.project = parseProject(JSONObject.fromObject(jsonResponse));
+        return this;
+    }
+
+    private Project parseProject(JSONObject json) {
+        final String name = getKeyOrNull(json, "name");
+        final String description = getKeyOrNull(json, "description");
+        final String version = getKeyOrNull(json, "version");
+        final String uuid = getKeyOrNull(json, "uuid");
+        final List<String> tags = json.has("tags") ? parseTags(json.getJSONArray("tags")) : Collections.emptyList();
+        final LocalDateTime lastBomImport = parseDateTime(getKeyOrNull(json, "lastBomImportStr"));
+        final String lastBomImportFormat = getKeyOrNull(json, "lastBomImportFormat");
+        final String lastInheritedRiskScoreStr = getKeyOrNull(json, "lastInheritedRiskScore");
+        final Double lastInheritedRiskScore = lastInheritedRiskScoreStr != null ? Double.parseDouble(lastInheritedRiskScoreStr) : null;
+        final String activeStr = getKeyOrNull(json, "active");
+        final Boolean active = activeStr != null ? Boolean.parseBoolean(activeStr) : null;
+        return new Project(name, description, version, uuid, tags, lastBomImport, lastBomImportFormat, lastInheritedRiskScore, active);
+    }
+
+    private String getKeyOrNull(JSONObject json, String key) {
+        return json.has(key) ? StringUtils.trimToNull(json.getString(key)) : null;
+    }
+
+    private LocalDateTime parseDateTime(String dateTime) {
+        if (dateTime == null) {
+            return null;
+        } else {
+            return LocalDateTime.parse(dateTime);
+        }
+    }
+
+    private List<String> parseTags(JSONArray tagArray) {
+        final List<String> tags = new ArrayList<>(tagArray.size());
+        for (int i = 0; i < tagArray.size(); i++) {
+            JSONObject tag = tagArray.getJSONObject(i);
+            tags.add(tag.getString("name"));
+        }
+        return tags;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/Project.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/Project.java
@@ -1,0 +1,69 @@
+package org.jenkinsci.plugins.DependencyTrack.model;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class Project implements Serializable {
+
+    private static final long serialVersionUID = 5615023685011011641L;
+
+    private String name;
+    private String description;
+    private String version;
+    private String uuid;
+    private List<String> tags;
+    private LocalDateTime lastBomImport;
+    private String lastBomImportFormat;
+    private Double lastInheritedRiskScore;
+    private Boolean active;
+
+    public Project(String name, String description, String version, String uuid, List<String> tags, LocalDateTime lastBomImport,
+                   String lastBomImportFormat, Double lastInheritedRiskScore, Boolean active) {
+        this.name = name;
+        this.description = description;
+        this.version = version;
+        this.uuid = uuid;
+        this.tags = tags;
+        this.lastBomImport = lastBomImport;
+        this.lastBomImportFormat = lastBomImportFormat;
+        this.lastInheritedRiskScore = lastInheritedRiskScore;
+        this.active = active;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public LocalDateTime getLastBomImport() {
+        return lastBomImport;
+    }
+
+    public String getLastBomImportFormat() {
+        return lastBomImportFormat;
+    }
+
+    public Double getLastInheritedRiskScore() {
+        return lastInheritedRiskScore;
+    }
+
+    public Boolean isActive() {
+        return active;
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages.properties
@@ -29,6 +29,7 @@ Builder.Unauthorized=Unauthorized. Ensure a valid API key is specified.
 Builder.Project.NotFound=The specified project could not be found
 Builder.Polling=Polling Dependency-Track for BOM processing status
 Builder.Polling.Timeout.Exceeded=Polling Dependency-Track for results is taking longer than expected - polling limit exceeded
+Builder.Project.Lookup=Looking up id of newly created project
 Builder.Findings.Processing=Processing findings
 Builder.Publisher.Response.Failure=An error occurred publishing results. Check Dependency-Track server logs for details.
 Builder.Threshold.Exceed=Findings exceed configured thresholds


### PR DESCRIPTION
Added a new Project model for holding project information returned
from the relatively new project/lookup api endpoint, for which
support was added to ApiClient.  The DependencyTrackPublisher
now uses this new functionality to fetch the project uuid before
looking up results if it does not already have the id.