### PR TITLE
Enable JobActions for pipelines.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
@@ -223,7 +223,7 @@ public class DependencyTrackPublisher extends ThresholdCapablePublisher implemen
                 final FindingParser parser = new FindingParser(build.getNumber(), jsonResponseBody).parse();
                 final ArrayList<Finding> findings = parser.getFindings();
                 final SeverityDistribution severityDistribution = parser.getSeverityDistribution();
-                final ResultAction projectAction = new ResultAction(findings, severityDistribution);
+                final ResultAction projectAction = new ResultAction(build, findings, severityDistribution);
                 build.addAction(projectAction);
 
                 // Get previous results and evaluate to thresholds

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/JobAction.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/JobAction.java
@@ -15,9 +15,9 @@
  */
 package org.jenkinsci.plugins.DependencyTrack;
 
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
 import hudson.model.Action;
+import hudson.model.Job;
+import hudson.model.Run;
 import net.sf.json.JSONArray;
 import org.jenkinsci.plugins.DependencyTrack.model.SeverityDistribution;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
@@ -26,9 +26,9 @@ import java.util.List;
 
 public class JobAction implements Action {
 
-    private AbstractProject<?, ?> project;
+    private Job<?, ?> project;
 
-    public JobAction(final AbstractProject<?, ?> project) {
+    public JobAction(final Job<?, ?> project) {
         this.project = project;
     }
 
@@ -47,7 +47,7 @@ public class JobAction implements Action {
         return "dtrackTrend";
     }
 
-    public AbstractProject<?, ?> getProject() {
+    public Job<?, ?> getProject() {
         return this.project;
     }
 
@@ -58,9 +58,9 @@ public class JobAction implements Action {
      */
     @SuppressWarnings("unused") // Called by jelly view
     public boolean isTrendVisible() {
-        final List<? extends AbstractBuild<?, ?>> builds = project.getBuilds();
+        final List<? extends Run<?, ?>> builds = project.getBuilds();
         int count = 0;
-        for (AbstractBuild<?, ?> currentBuild : builds) {
+        for (Run<?, ?> currentBuild : builds) {
             final ResultAction action = currentBuild.getAction(ResultAction.class);
             if (action != null) {
                 return true;
@@ -82,9 +82,9 @@ public class JobAction implements Action {
     @SuppressWarnings("unused") // Called by jelly view
     public JSONArray getSeverityDistributionTrend() {
         final List<SeverityDistribution> severityDistributions = new ArrayList<>();
-        final List<? extends AbstractBuild<?, ?>> builds = project.getBuilds();
+        final List<? extends Run<?, ?>> builds = project.getBuilds();
         int count = 0;
-        for (AbstractBuild<?, ?> currentBuild : builds) {
+        for (Run<?, ?> currentBuild : builds) {
             final ResultAction action = currentBuild.getAction(ResultAction.class);
             if (action != null) {
                 if (action.getSeverityDistribution() != null) {

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/ResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/ResultAction.java
@@ -15,28 +15,34 @@
  */
 package org.jenkinsci.plugins.DependencyTrack;
 
+import hudson.model.Action;
 import hudson.model.Run;
 import jenkins.model.RunAction2;
+import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import net.sf.json.JsonConfig;
 import org.jenkinsci.plugins.DependencyTrack.model.Finding;
 import org.jenkinsci.plugins.DependencyTrack.model.SeverityDistribution;
 import org.jenkinsci.plugins.DependencyTrack.transformer.FindingsTransformer;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
-import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
-public class ResultAction implements RunAction2, Serializable {
+public class ResultAction implements RunAction2, SimpleBuildStep.LastBuildAction {
 
-    private static final long serialVersionUID = -3741322502842596768L;
-    private transient Run run;
+    private Run<?, ?> run;
     private ArrayList<Finding> findings;
     private SeverityDistribution severityDistribution;
+    private List<JobAction> projectActions;
 
-    public ResultAction(ArrayList<Finding> findings, SeverityDistribution severityDistribution) {
+    public ResultAction(Run<?, ?> build, ArrayList<Finding> findings, SeverityDistribution severityDistribution) {
         this.findings = findings;
         this.severityDistribution = severityDistribution;
+
+        List<JobAction> projectActions = new ArrayList<>();
+        projectActions.add(new JobAction(build.getParent()));
+        this.projectActions = projectActions;
     }
 
     @Override
@@ -62,6 +68,11 @@ public class ResultAction implements RunAction2, Serializable {
     @Override
     public void onLoad(Run<?, ?> run) {
         this.run = run;
+    }
+
+    @Override
+    public Collection<? extends Action> getProjectActions() {
+        return this.projectActions;
     }
 
     public Run getRun() {


### PR DESCRIPTION
Subclass build ResultAction from SimpleBuildStep.LastBuildAction so
that we can refer to the project JobAction, needed for jenkins
to surface plugin results on the job overiew page for pipeline builds.