### PR TITLE
Throw exceptions on deptrack failures

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/ApiClientException.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/ApiClientException.java
@@ -15,7 +15,9 @@
  */
 package org.jenkinsci.plugins.DependencyTrack;
 
-public class ApiClientException extends Exception {
+import java.io.IOException;
+
+public class ApiClientException extends IOException {
 
     public ApiClientException(String message) {
         super(message);


### PR DESCRIPTION
Switch to throw exceptions rather than unilaterally setting build status
(and not notifying caller of failure). Allows pipeline builds
to both abort on deptrack failure, as well as catch and suppress
deptrack errors, if desired. Make ApiClientException an IOException,
and don't catch it anymore, either.