### PR TITLE
Add apiUrl to allow for separation of urls. One for UI, another for API

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/ApiClient.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/ApiClient.java
@@ -68,7 +68,7 @@ public class ApiClient {
      * the base url to DT instance without trailing slashes, e.g.
      * "http://host.tld:port"
      */
-    private final String baseUrl;
+    private final String baseApiUrl;
 
     /**
      * the api key to authorize with against DT
@@ -90,7 +90,7 @@ public class ApiClient {
     @NonNull
     public String testConnection() throws ApiClientException {
         try {
-            final HttpURLConnection conn = (HttpURLConnection) new URL(baseUrl + PROJECT_URL).openConnection();
+            final HttpURLConnection conn = (HttpURLConnection) new URL(baseApiUrl + PROJECT_URL).openConnection();
             conn.setRequestProperty(HEADER_ACCEPT, MEDIATYPE_JSON);
             conn.setRequestProperty(API_KEY_HEADER, apiKey);
             conn.setConnectTimeout(connectionTimeout * MS_TO_S_FACTOR);
@@ -125,7 +125,7 @@ public class ApiClient {
     @NonNull
     private List<Project> getProjectsPaged(int page) throws ApiClientException {
         try {
-            final HttpURLConnection conn = (HttpURLConnection) new URL(baseUrl + PROJECT_URL + "?limit=500&excludeInactive=true&page=" + page).openConnection();
+            final HttpURLConnection conn = (HttpURLConnection) new URL(baseApiUrl + PROJECT_URL + "?limit=500&excludeInactive=true&page=" + page).openConnection();
             conn.setRequestProperty(HEADER_ACCEPT, MEDIATYPE_JSON);
             conn.setRequestProperty(API_KEY_HEADER, apiKey);
             conn.setConnectTimeout(connectionTimeout * MS_TO_S_FACTOR);
@@ -149,7 +149,7 @@ public class ApiClient {
     @NonNull
     public Project lookupProject(String projectName, String projectVersion) throws ApiClientException {
         try {
-            final HttpURLConnection conn = (HttpURLConnection) new URL(baseUrl + PROJECT_LOOKUP_URL + "?"
+            final HttpURLConnection conn = (HttpURLConnection) new URL(baseApiUrl + PROJECT_LOOKUP_URL + "?"
                     + PROJECT_LOOKUP_NAME_PARAM + "=" + URLEncoder.encode(projectName, StandardCharsets.UTF_8.name()) + "&"
                     + PROJECT_LOOKUP_VERSION_PARAM + "=" + URLEncoder.encode(projectVersion, StandardCharsets.UTF_8.name()))
                     .openConnection();
@@ -186,7 +186,7 @@ public class ApiClient {
     @NonNull
     public List<Finding> getFindings(String projectUuid) throws ApiClientException {
         try {
-            final HttpURLConnection conn = (HttpURLConnection) new URL(baseUrl + PROJECT_FINDINGS_URL + "/" + URLEncoder.encode(projectUuid, StandardCharsets.UTF_8.name()))
+            final HttpURLConnection conn = (HttpURLConnection) new URL(baseApiUrl + PROJECT_FINDINGS_URL + "/" + URLEncoder.encode(projectUuid, StandardCharsets.UTF_8.name()))
                     .openConnection();
             conn.setDoOutput(true);
             conn.setRequestProperty(API_KEY_HEADER, apiKey);
@@ -232,7 +232,7 @@ public class ApiClient {
         }
         byte[] payloadBytes = jsonObject.toString().getBytes(StandardCharsets.UTF_8);
         // Creates the request and connects
-        final HttpURLConnection conn = (HttpURLConnection) new URL(baseUrl + BOM_URL).openConnection();
+        final HttpURLConnection conn = (HttpURLConnection) new URL(baseApiUrl + BOM_URL).openConnection();
         conn.setDoOutput(true);
         conn.setRequestMethod("PUT");
         conn.setRequestProperty(HEADER_CONTENT_TYPE, MEDIATYPE_JSON);
@@ -285,7 +285,7 @@ public class ApiClient {
     @NonNull
     public boolean isTokenBeingProcessed(String token) throws ApiClientException {
         try {
-            final HttpURLConnection conn = (HttpURLConnection) new URL(baseUrl + BOM_TOKEN_URL + "/" + URLEncoder.encode(token, StandardCharsets.UTF_8.name()))
+            final HttpURLConnection conn = (HttpURLConnection) new URL(baseApiUrl + BOM_TOKEN_URL + "/" + URLEncoder.encode(token, StandardCharsets.UTF_8.name()))
                     .openConnection();
             conn.setDoOutput(true);
             conn.setRequestProperty(API_KEY_HEADER, apiKey);

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/ApiClientFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/ApiClientFactory.java
@@ -22,5 +22,5 @@ package org.jenkinsci.plugins.DependencyTrack;
 @FunctionalInterface
 interface ApiClientFactory {
 
-    ApiClient create(final String baseUrl, final String apiKey, final ConsoleLogger logger, int connectionTimeout, int readTimeout);
+    ApiClient create(final String baseApiUrl, final String apiKey, final ConsoleLogger logger, int connectionTimeout, int readTimeout);
 }

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
@@ -153,9 +153,10 @@ public final class DependencyTrackPublisher extends ThresholdCapablePublisher im
             throw new AbortException(Messages.Builder_Artifact_NonExist(effectiveArtifact));
         }
 
+        final String effectiveUrl = getEffectiveUrl();
         final String effectiveApiUrl = getEffectiveApiUrl();
         final String effectiveApiKey = getEffectiveApiKey(run);
-        logger.log(Messages.Builder_Publishing(effectiveApiUrl));
+        logger.log(Messages.Builder_Publishing(effectiveUrl));
         final ApiClient apiClient = clientFactory.create(effectiveApiUrl, effectiveApiKey, logger, descriptor.getDependencyTrackConnectionTimeout(), descriptor.getDependencyTrackReadTimeout());
         final UploadResult uploadResult = apiClient.upload(projectId, effectiveProjectName, effectiveProjectVersion,
                 artifactFilePath, isEffectiveAutoCreateProjects());

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
@@ -171,7 +171,7 @@ public final class DependencyTrackPublisher extends ThresholdCapablePublisher im
         linkAction.setProjectVersion(effectiveProjectVersion);
         run.addOrReplaceAction(linkAction);
 
-        logger.log(Messages.Builder_Success(String.format("%s/projects/%s", effectiveApiUrl, projectId != null ? projectId : StringUtils.EMPTY)));
+        logger.log(Messages.Builder_Success(String.format("%s/projects/%s", effectiveUrl, projectId != null ? projectId : StringUtils.EMPTY)));
 
         if (synchronous && StringUtils.isNotBlank(uploadResult.getToken())) {
             publishAnalysisResult(logger, apiClient, uploadResult.getToken(), run, effectiveProjectName, effectiveProjectVersion);

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DescriptorImpl.java
@@ -219,12 +219,12 @@ public final class DescriptorImpl extends BuildStepDescriptor<Publisher> impleme
      */
     public FormValidation doTestConnection(@QueryParameter final String dependencyTrackApiUrl, @QueryParameter final String dependencyTrackApiKey, @AncestorInPath @Nullable Item item) {
         // api-url may come from instance-config. if empty, then take it from global config (this)
-        final String url = Optional.ofNullable(PluginUtil.parseBaseUrl(dependencyTrackApiUrl)).orElse(getDependencyTrackApiUrl());
+        final String apiUrl = Optional.ofNullable(PluginUtil.parseBaseUrl(dependencyTrackApiUrl)).orElse(getDependencyTrackApiUrl());
         // api-key may come from instance-config. if empty, then take it from global config (this)
         final String apiKey = lookupApiKey(Optional.ofNullable(StringUtils.trimToNull(dependencyTrackApiKey)).orElse(getDependencyTrackApiKey()), item);
-        if (doCheckDependencyTrackApiUrl(url).kind == FormValidation.Kind.OK && StringUtils.isNotBlank(apiKey)) {
+        if (doCheckDependencyTrackApiUrl(apiUrl).kind == FormValidation.Kind.OK && StringUtils.isNotBlank(apiKey)) {
             try {
-                final ApiClient apiClient = getClient(url, apiKey);
+                final ApiClient apiClient = getClient(apiUrl, apiKey);
                 final String result = apiClient.testConnection();
                 return result.startsWith("Dependency-Track v") ? FormValidation.ok("Connection successful - " + result) : FormValidation.error("Connection failed - " + result);
             } catch (ApiClientException e) {

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DescriptorImpl.java
@@ -218,7 +218,7 @@ public final class DescriptorImpl extends BuildStepDescriptor<Publisher> impleme
      * @return FormValidation
      */
     public FormValidation doTestConnection(@QueryParameter final String dependencyTrackApiUrl, @QueryParameter final String dependencyTrackApiKey, @AncestorInPath @Nullable Item item) {
-        // url may come from instance-config. if empty, then take it from global config (this)
+        // api-url may come from instance-config. if empty, then take it from global config (this)
         final String url = Optional.ofNullable(PluginUtil.parseBaseUrl(dependencyTrackApiUrl)).orElse(getDependencyTrackApiUrl());
         // api-key may come from instance-config. if empty, then take it from global config (this)
         final String apiKey = lookupApiKey(Optional.ofNullable(StringUtils.trimToNull(dependencyTrackApiKey)).orElse(getDependencyTrackApiKey()), item);

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config.jelly
@@ -41,6 +41,9 @@ limitations under the License.
     <f:entry title="${%dependencytrack.url}" field="dependencyTrackUrl" help="/plugin/dependency-track/help-dt-url.html">
         <f:textbox id="dependencytrack.url" />
     </f:entry>
+    <f:entry title="${%dependencytrack.apiurl}" field="dependencyTrackApiUrl" help="/plugin/dependency-track/help-dt-apiurl.html">
+        <f:textbox id="dependencytrack.apiurl" />
+    </f:entry>
     <f:entry title="${%dependencytrack.apikey}" field="dependencyTrackApiKey" help="/plugin/dependency-track/help-dt-apikey.html">
         <c:select id="dependencytrack.apikey" />
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config.properties
@@ -18,6 +18,7 @@ projectVersion=Dependency-Track project version
 artifact=Artifact
 enable.synchronous=Enable synchronous publishing mode
 dependencytrack.url=Dependency-Track URL
+dependencytrack.apiurl=Dependency-Track API-Server URL
 dependencytrack.apikey=API key
 dependencytrack.autocreate=Auto Create Projects
 dependencytrack.connection.test=Test Connection

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.jelly
@@ -20,6 +20,9 @@ limitations under the License.
         <f:entry title="${%dependencytrack.url}" field="dependencyTrackUrl" help="/plugin/dependency-track/help-dt-url.html">
             <f:textbox id="dependencytrack.url"/>
         </f:entry>
+        <f:entry title="${%dependencytrack.apiurl}" field="dependencyTrackApiUrl" help="/plugin/dependency-track/help-dt-url.html">
+            <f:textbox id="dependencytrack.apiurl"/>
+        </f:entry>
         <f:entry title="${%dependencytrack.apikey}" field="dependencyTrackApiKey" help="/plugin/dependency-track/help-dt-apikey.html">
             <c:select id="dependencytrack.apikey" />
         </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.properties
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 dependencytrack.url=Dependency-Track URL
+dependencytrack.apiurl=Dependency-Track API-Server URL
 dependencytrack.apikey=API key
 dependencytrack.autocreate=Auto Create Projects
 dependencytrack.polling.timeout=Polling Timeout

--- a/src/main/webapp/help-dt-apiurl.html
+++ b/src/main/webapp/help-dt-apiurl.html
@@ -1,0 +1,3 @@
+<div>
+    The base URL to Dependency-Track API-Server v4 or higher. (i.e. http://hostname:port)
+</div>

--- a/src/test/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisherTest.java
@@ -225,8 +225,8 @@ public class DependencyTrackPublisherTest {
     public void testUseOfOverridenProperties() throws IOException {
         File tmp = tmpDir.newFile();
         FilePath workDir = new FilePath(tmpDir.getRoot());
-        ApiClientFactory factory = (url, apiKey, logger, connTimeout, readTimeout) -> {
-            assertThat(url).isEqualTo("http://test.tld");
+        ApiClientFactory factory = (apiUrl, apiKey, logger, connTimeout, readTimeout) -> {
+            assertThat(apiUrl).isEqualTo("http://api.test.tld");
             assertThat(apiKey).isEqualTo(apikey);
             assertThat(logger).isInstanceOf(ConsoleLogger.class);
             return client;
@@ -234,7 +234,7 @@ public class DependencyTrackPublisherTest {
         final DependencyTrackPublisher uut = new DependencyTrackPublisher(tmp.getName(), false, factory);
         uut.setProjectId("uuid-1");
         uut.setAutoCreateProjects(Boolean.TRUE);
-        uut.setDependencyTrackUrl("http://test.tld");
+        uut.setDependencyTrackApiUrl("http://api.test.tld");
         uut.setDependencyTrackApiKey(apikeyId);
 
         when(client.upload(eq("uuid-1"), isNull(), isNull(), any(FilePath.class), eq(true)))

--- a/src/test/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisherTest.java
@@ -234,6 +234,7 @@ public class DependencyTrackPublisherTest {
         final DependencyTrackPublisher uut = new DependencyTrackPublisher(tmp.getName(), false, factory);
         uut.setProjectId("uuid-1");
         uut.setAutoCreateProjects(Boolean.TRUE);
+        uut.setDependencyTrackUrl("http://test.tld");
         uut.setDependencyTrackApiUrl("http://api.test.tld");
         uut.setDependencyTrackApiKey(apikeyId);
 

--- a/src/test/java/org/jenkinsci/plugins/configuration/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configuration/ConfigurationAsCodeTest.java
@@ -23,6 +23,7 @@ public class ConfigurationAsCodeTest {
 
         assertThat(descriptor)
                 .returns("https://example.org/deptrack", DescriptorImpl::getDependencyTrackUrl)
+                .returns("https://api.example.org/deptrack", DescriptorImpl::getDependencyTrackApiUrl)
                 .returns("R4nD0m", DescriptorImpl::getDependencyTrackApiKey)
                 .returns(false, DescriptorImpl::isDependencyTrackAutoCreateProjects)
                 .returns(5, DescriptorImpl::getDependencyTrackPollingTimeout)

--- a/src/test/resources/dependency_track_test_config.yml
+++ b/src/test/resources/dependency_track_test_config.yml
@@ -1,6 +1,7 @@
 unclassified:
   dependencyTrackPublisher:
     dependencyTrackUrl: https://example.org/deptrack
+    dependencyTrackApiUrl: https://api.example.org/deptrack
     dependencyTrackApiKey: R4nD0m
     dependencyTrackAutoCreateProjects: false
     dependencyTrackPollingTimeout: 5


### PR DESCRIPTION
Due to changes in Dependency-Track 4.0, i.e. separate URL for UI and API. This plugin needs to have to URL-inputs, one for the UI another for the API.