### PR TITLE
modify connection test to check team permission as well 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### ⚠ Breaking
 ### ⭐ New Features
+- Add check for serve-side permissions (fixes [#13](https://github.com/jenkinsci/dependency-track-plugin/issues/13))
+
 ### 🐞 Bugs Fixed
 
 ## v4.1.1 - 2022-03-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 ### ⚠ Breaking
 ### ⭐ New Features
-- Add check for serve-side permissions (fixes [#13](https://github.com/jenkinsci/dependency-track-plugin/issues/13))
+- The connection test will also check server-side permissions for Dependency-Track v4.4 and newer (fixes [#13](https://github.com/jenkinsci/dependency-track-plugin/issues/13))
 
 ### 🐞 Bugs Fixed
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Once configured with a valid URL and API key, simply configure a job to publish 
 
 **Artifact:** Specifies the file to upload. Paths are relative from the Jenkins workspace. The use of environment variables in the form `${VARIABLE}` is supported here.
 
-**Enable synchronous publishing mode**: Uploads a SBOM to Dependency-Track and waits for Dependency-Track to process and return results. The results returned are identical to the auditable findings but exclude findings that have previously been suppressed. Analysis decisions and vulnerability details are included in the response. Synchronous mode is possible with Dependency-Track v3.3.1 and higher.
+**Enable synchronous publishing mode**: Uploads a SBOM to Dependency-Track and waits for Dependency-Track to process and return results. The results returned are identical to the auditable findings but exclude findings that have previously been suppressed. Analysis decisions and vulnerability details are included in the response. Synchronous mode is possible with Dependency-Track v3.3.1 and higher. The provided API key requires the `VIEW_VULNERABILITY` permission to use this feature with Dependency-Track v4.4 and newer!
 
 **Update project properties**: Allows updating of some project properties after uploading the BOM. The provided API key requires the `PORTFOLIO_MANAGEMENT` permission to use this feature! These properties are:
 - tags

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DescriptorImpl.java
@@ -296,7 +296,7 @@ public final class DescriptorImpl extends BuildStepDescriptor<Publisher> impleme
         final Set<String> allPermissions = new TreeSet<>(team.getPermissions());
         allPermissions.addAll(requiredPermissions);
         allPermissions.addAll(optionalPermissions);
-        final StringBuffer sb = new StringBuffer(Messages.Publisher_ConnectionTest_Success("Dependency-Track v" + version));
+        final StringBuilder sb = new StringBuilder(Messages.Publisher_ConnectionTest_Success("Dependency-Track v" + version));
         sb.append("<p class=\"team\">");
         sb.append(Messages.Publisher_PermissionTest_Team(Util.escape(team.getName())));
         sb.append("</p><ul>");

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/TeamParser.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/TeamParser.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 OWASP.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jenkinsci.plugins.DependencyTrack;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.experimental.UtilityClass;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.DependencyTrack.model.Team;
+
+/**
+ *
+ * @author Ronny "Sephiroth" Perinke <sephiroth@sephiroth-j.de>
+ */
+@UtilityClass
+class TeamParser {
+
+    Team parse(JSONObject json) {
+        final Set<String> permissions = json.getJSONArray("permissions").stream()
+                .map(JSONObject.class::cast)
+                .map(o -> o.getString("name"))
+                .collect(Collectors.toSet());
+        
+        return Team.builder()
+                .name(json.getString("name"))
+                .permissions(permissions)
+                .build();
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/Permissions.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/Permissions.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 OWASP.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jenkinsci.plugins.DependencyTrack.model;
+
+/**
+ *
+ * @author Ronny "Sephiroth" Perinke <sephiroth@sephiroth-j.de>
+ */
+public enum Permissions {
+    BOM_UPLOAD, VIEW_PORTFOLIO, VULNERABILITY_ANALYSIS, PROJECT_CREATION_UPLOAD, PORTFOLIO_MANAGEMENT, VIEW_VULNERABILITY
+}

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/Team.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/Team.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 OWASP.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jenkinsci.plugins.DependencyTrack.model;
+
+import java.util.Set;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ *
+ * @author Ronny "Sephiroth" Perinke <sephiroth@sephiroth-j.de>
+ */
+@Value
+@Builder
+public class Team {
+    private String name;
+    private Set<String> permissions;
+}

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config.jelly
@@ -51,10 +51,10 @@ limitations under the License.
             <f:entry title="${%dependencytrack.apikey}" field="dependencyTrackApiKey">
                 <c:select id="dependencytrack.apikey" />
             </f:entry>
-            <f:validateButton title="${%dependencytrack.connection.test}" progress="${%dependencytrack.connection.testing}" method="testConnection" with="dependencyTrackUrl,dependencyTrackApiKey" />
             <f:entry title="${%dependencytrack.autocreate}" field="autoCreateProjects">
                 <f:checkbox id="dependencytrack.autocreate" />
             </f:entry>
+            <f:validateButton title="${%dependencytrack.connection.test}" progress="${%dependencytrack.connection.testing}" method="testConnectionJob" with="dependencyTrackUrl,dependencyTrackApiKey,autoCreateProjects,synchronous" />
         </f:optionalBlock>
     </f:section>
 

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config.jelly
@@ -54,7 +54,7 @@ limitations under the License.
             <f:entry title="${%dependencytrack.autocreate}" field="autoCreateProjects">
                 <f:checkbox id="dependencytrack.autocreate" />
             </f:entry>
-            <f:validateButton title="${%dependencytrack.connection.test}" progress="${%dependencytrack.connection.testing}" method="testConnectionJob" with="dependencyTrackUrl,dependencyTrackApiKey,autoCreateProjects,synchronous" />
+            <f:validateButton title="${%dependencytrack.connection.test}" progress="${%dependencytrack.connection.testing}" method="testConnectionJob" with="dependencyTrackUrl,dependencyTrackApiKey,autoCreateProjects,synchronous,projectProperties" />
         </f:optionalBlock>
     </f:section>
 

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.jelly
@@ -15,6 +15,7 @@ limitations under the License.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+    <l:css src="plugin/dependency-track/css/global.css" />
 
     <f:section title="Dependency-Track">
         <f:entry title="${%dependencytrack.url}" field="dependencyTrackUrl">
@@ -43,7 +44,7 @@ limitations under the License.
                 <f:number id="dependencytrack.read.timeout" default="5" clazz="non-negative-number-required" min="0" />
             </f:entry>
         </f:advanced>
-        <f:validateButton title="${%dependencytrack.connection.test}" progress="${%dependencytrack.connection.testing}" method="testConnection" with="dependencyTrackUrl,dependencyTrackApiKey" />
+        <f:validateButton title="${%dependencytrack.connection.test}" progress="${%dependencytrack.connection.testing}" method="testConnectionGlobal" with="dependencyTrackUrl,dependencyTrackApiKey,dependencyTrackAutoCreateProjects" />
     </f:section>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/help-synchronous.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/help-synchronous.html
@@ -11,4 +11,5 @@
     <p>
         Synchronous mode is possible with Dependency-Track v3.3.1 and higher.
     </p>
+    <p>The API key provided requires the VIEW_VULNERABILITY permission to use this feature with Dependency-Track v4.4 and newer!</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/help-synchronous_de.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/help-synchronous_de.html
@@ -2,4 +2,5 @@
     <p>Beim synchronen Veröffentlichungsmodus wird nach erfolgreichem Hochladen der BOM auf die Analyseergebnisse gewartet.</p>
     <p>Damit können die Analyseergebnisse direkt in Jenkins pro Build gespeichert und dargestellt werden - inklusive interaktivem Verlaufsdiagram.</p>
     <p>Der synchrone Veröffentlichungsmodus ist mit Dependency-Track Version 3.3.1 und neuer möglich.</p>
+    <p>Der verwendete API-Schlüssel benötigt die Berechtigung "VIEW_VULNERABILITY", um diese Funktion mit Dependency-Track Version 4.4 und neuer zu nutzen!</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages.properties
@@ -19,6 +19,11 @@ Publisher.ConnectionTest.Error=Connection failed - {0}
 Publisher.ConnectionTest.Warning=URL must be valid and Api-Key must not be empty
 Publisher.ConnectionTest.UrlMalformed=The specified value is not a valid URL
 Publisher.ConnectionTest.InvalidProtocols=Only URLs with http and https are supported
+Publisher.PermissionTest.Team=Permissions for Team <q>{0}</q>
+Publisher.PermissionTest.Okay=<q>{0}</q> - okay
+Publisher.PermissionTest.Missing=<q>{0}</q> - is required but absent!
+Publisher.PermissionTest.Warning=<q>{0}</q> - is present but not necessary!
+Publisher.PermissionTest.Optional=<q>{0}</q> - optional
 
 Builder.Publishing=Publishing artifact to Dependency-Track - {0}
 Builder.Artifact.NonExist=The specified artifact "{0}" does not exist

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages_de.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages_de.properties
@@ -19,6 +19,11 @@ Publisher.ConnectionTest.Error=Verbindung fehlgeschlagen - {0}
 Publisher.ConnectionTest.Warning=Die URL muss g\u00fcltig und der API-Schl\u00fcssel darf nicht leer sein
 Publisher.ConnectionTest.UrlMalformed=Der angegebene Wert ist keine g\u00fcltige URL
 Publisher.ConnectionTest.InvalidProtocols=Nur URLs mit http oder https werden unterst\u00fctzt
+Publisher.PermissionTest.Team=Berechtigungen f\u00fcr Team <q>{0}</q>
+Publisher.PermissionTest.Okay=<q>{0}</q> - okay
+Publisher.PermissionTest.Missing=<q>{0}</q> - fehlt aber ist erforderlich!
+Publisher.PermissionTest.Warning=<q>{0}</q> - ist vorhanden aber nicht erforderlich!
+Publisher.PermissionTest.Optional=<q>{0}</q> - optional
 
 Builder.Publishing=Hochladen von Artefakt in Dependency-Track - {0}
 Builder.Artifact.NonExist=Das angegebene Artefakt "{0}" wurde nicht gefunden!

--- a/src/main/webapp/css/config.css
+++ b/src/main/webapp/css/config.css
@@ -1,13 +1,44 @@
-.dependency-track.multi-line-input-row {
+[descriptorid="org.jenkinsci.plugins.DependencyTrack.DependencyTrackPublisher"] .dependency-track.multi-line-input-row {
     display: grid;
     grid-template-rows: auto;
     grid-template-columns: auto auto auto auto;
     grid-column-gap: .5em;
 }
-fieldset.dependency-track {
+[descriptorid="org.jenkinsci.plugins.DependencyTrack.DependencyTrackPublisher"] fieldset.dependency-track {
     border: 2px dashed var(--medium-grey);
     margin: .5em 0;
 }
-fieldset.dependency-track legend img {
+[descriptorid="org.jenkinsci.plugins.DependencyTrack.DependencyTrackPublisher"] fieldset.dependency-track legend img {
     width: var(--btn-large-line-height);
+}
+[descriptorid="org.jenkinsci.plugins.DependencyTrack.DependencyTrackPublisher"] .form-container.tr .help-sibling .team q {
+    color: var(--primary);
+}
+
+[descriptorid="org.jenkinsci.plugins.DependencyTrack.DependencyTrackPublisher"] .form-container.tr .help-sibling .permission.okay {
+    color: var(--success);
+}
+[descriptorid="org.jenkinsci.plugins.DependencyTrack.DependencyTrackPublisher"] .form-container.tr .help-sibling .permission.okay::after {
+    content: "\2705";
+    font-size: var(--font-size-base);
+}
+[descriptorid="org.jenkinsci.plugins.DependencyTrack.DependencyTrackPublisher"] .form-container.tr .help-sibling .permission.missing::after {
+    content: "\274C";
+    font-size: var(--font-size-base);
+}
+[descriptorid="org.jenkinsci.plugins.DependencyTrack.DependencyTrackPublisher"] .form-container.tr .help-sibling .permission.missing {
+    color: var(--danger);
+    font-weight: bold;
+}
+[descriptorid="org.jenkinsci.plugins.DependencyTrack.DependencyTrackPublisher"] .form-container.tr .help-sibling .permission.missing::after {
+    content: "\26D4";
+    font-size: var(--font-size-base);
+}
+[descriptorid="org.jenkinsci.plugins.DependencyTrack.DependencyTrackPublisher"] .form-container.tr .help-sibling .permission.warn {
+    color: var(--warning);
+    font-weight: bold;
+}
+[descriptorid="org.jenkinsci.plugins.DependencyTrack.DependencyTrackPublisher"] .form-container.tr .help-sibling .permission.warn::after {
+    content: "\26A0";
+    font-size: var(--font-size-base);
 }

--- a/src/main/webapp/css/global.css
+++ b/src/main/webapp/css/global.css
@@ -1,0 +1,31 @@
+[name="org-jenkinsci-plugins-DependencyTrack-DependencyTrackPublisher"] + .form-container.tr[nameref] .help-sibling .team q {
+    color: var(--primary);
+}
+
+[name="org-jenkinsci-plugins-DependencyTrack-DependencyTrackPublisher"] + .form-container.tr[nameref] .help-sibling .permission.okay {
+    color: var(--success);
+}
+[name="org-jenkinsci-plugins-DependencyTrack-DependencyTrackPublisher"] + .form-container.tr[nameref] .help-sibling .permission.okay::after {
+    content: "\2705";
+    font-size: var(--font-size-base);
+}
+[name="org-jenkinsci-plugins-DependencyTrack-DependencyTrackPublisher"] + .form-container.tr[nameref] .help-sibling .permission.missing::after {
+    content: "\274C";
+    font-size: var(--font-size-base);
+}
+[name="org-jenkinsci-plugins-DependencyTrack-DependencyTrackPublisher"] + .form-container.tr[nameref] .help-sibling .permission.missing {
+    color: var(--danger);
+    font-weight: bold;
+}
+[name="org-jenkinsci-plugins-DependencyTrack-DependencyTrackPublisher"] + .form-container.tr[nameref] .help-sibling .permission.missing::after {
+    content: "\26D4";
+    font-size: var(--font-size-base);
+}
+[name="org-jenkinsci-plugins-DependencyTrack-DependencyTrackPublisher"] + .form-container.tr[nameref] .help-sibling .permission.warn {
+    color: var(--warning);
+    font-weight: bold;
+}
+[name="org-jenkinsci-plugins-DependencyTrack-DependencyTrackPublisher"] + .form-container.tr[nameref] .help-sibling .permission.warn::after {
+    content: "\26A0";
+    font-size: var(--font-size-base);
+}


### PR DESCRIPTION
starting with DTrack 4.4.0 it is possible to check the permissions of a team.
the connection test will use the old behavior for DT below 4.4.
for DT 4.4+ the new endpoint will be used to check for required permissions. this includes auto-creation (global + job) and sync-mode (job-only).