### PR TITLE
get latest succesful build instead of latest build with analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### 🐞 Bugs Fixed
 - classic jobs with sync mode and no project ID used the looked-up ID in future runs, although they should not (fixes [#98](https://github.com/jenkinsci/dependency-track-plugin/issues/98))
+- When using "New Findings" thresholds, the plugin is now looking for the latest succesful build with a report instead of just the previous build with the report.
 
 ## v4.1.1 - 2022-03-06
 ### ⚠ Breaking

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ When Synchronous mode is enabled, thresholds can be defined which can optionally
 
 **Total Findings:** Sets the threshold for the total number of critical, high, medium, or low severity findings allowed. If the number of findings equals or is greater than the threshold for any one of the severities, the job status will be changed to UNSTABLE or FAILURE.
 
-**New Findings:** Sets the threshold for the number of new critical, high, medium, or low severity findings allowed. If the number of new findings equals or is greater than the previous builds finding for any one of the severities, the job status will be changed to UNSTABLE or FAILURE. The previous build is the one that is not aborted and has an analysis result of Dependency-Track, which does not necessarily have to be the immediately previous build.
+**New Findings:** Sets the threshold for the number of new critical, high, medium, or low severity findings allowed. If the number of new findings equals or is greater than the previous builds finding for any one of the severities, the job status will be changed to UNSTABLE or FAILURE. The previous build is the one that is successful and has an analysis result of Dependency-Track, which does not necessarily have to be the immediately previous build.
 
 ## Examples
 ### Declarative Pipeline

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
@@ -440,9 +440,9 @@ public final class DependencyTrackPublisher extends Recorder implements SimpleBu
      */
     @Nullable
     private Run<?, ?> getPreviousBuildWithAnalysisResult(final @NonNull Run<?, ?> run) {
-        Run<?, ?> r = run.getPreviousBuiltBuild();
+        Run<?, ?> r = run.getPreviousSuccessfulBuild();
         while (r != null && (r.getResult() == null || r.getResult() == Result.NOT_BUILT || r.getAction(ResultAction.class) == null)) {
-            r = r.getPreviousBuiltBuild();
+            r = r.getPreviousSuccessfulBuild();
         }
         return r;
     }

--- a/src/test/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisherTest.java
@@ -211,11 +211,11 @@ public class DependencyTrackPublisherTest {
         when(buildWithResultAction.getAction(ResultAction.class)).thenReturn(new ResultAction(Collections.emptyList(), new SeverityDistribution(42)));
         Run buildWithNoResultAction = mock(Run.class);
         when(buildWithNoResultAction.getResult()).thenReturn(Result.SUCCESS);
-        when(buildWithNoResultAction.getPreviousBuiltBuild()).thenReturn(buildWithResultAction);
+        when(buildWithNoResultAction.getPreviousSuccessfulBuild()).thenReturn(buildWithResultAction);
         Run abortedBuild = mock(Run.class);
         when(abortedBuild.getResult()).thenReturn(Result.NOT_BUILT);
-        when(abortedBuild.getPreviousBuiltBuild()).thenReturn(buildWithNoResultAction);
-        when(build.getPreviousBuiltBuild()).thenReturn(abortedBuild);
+        when(abortedBuild.getPreviousSuccessfulBuild()).thenReturn(buildWithNoResultAction);
+        when(build.getPreviousSuccessfulBuild()).thenReturn(abortedBuild);
 
         assertThatCode(() -> uut.perform(build, workDir, env, launcher, listener)).doesNotThrowAnyException();
         verify(client, times(2)).isTokenBeingProcessed("token-1");


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

We integrated Dependency Track plugin in our Jenkins setup. The vulnerability checks at build time works well.

But we spotted an unwanted side effects when we want to interrupt a non compliant build (regarding our defined thresholds). We want only to stop builds based on "New Findings" but the plugin is looking for the previous build with a dependency track report in it. Which means that the previous has been interrupted because of vulnerable dependencies, relaunching it will make it compliant and will allow to "bypass" our security gate.

The purpose of this pull request is to get the latest "successful" and with a report build in Jenkins instead of the one with a report only. Changes have been tested on our Jenkins instance.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

