### PR TITLE
Avoid usage of an empty distribution for the first build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - require Jenkins 2.414.1 or newer
 - require Java 11 or newer ([required since Jenkins 2.361.1](https://www.jenkins.io/blog/2022/06/28/require-java-11/))
 - require Dependency-Track 4.9 or newer
+- New findings are only evaluated from the second build onwards ([#113](https://github.com/jenkinsci/dependency-track-plugin/issues/113))
 
 ### ⭐ New Features
 - Allow `overrideGlobals` to override global timeout and interval settings ([#182](https://github.com/jenkinsci/dependency-track-plugin/issues/182))

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
@@ -340,13 +340,17 @@ public final class DependencyTrackPublisher extends Recorder implements SimpleBu
         final SeverityDistribution previousSeverityDistribution = Optional.ofNullable(getPreviousBuildWithAnalysisResult(build))
                 .map(previousBuild -> previousBuild.getAction(ResultAction.class))
                 .map(ResultAction::getSeverityDistribution)
-                .orElseGet(() -> new SeverityDistribution(0));
+                .orElse(null);
 
         evaluateRiskGates(build, logger, severityDistribution, previousSeverityDistribution);
     }
 
     private void evaluateRiskGates(final Run<?, ?> build, final ConsoleLogger logger, final SeverityDistribution currentDistribution, final SeverityDistribution previousDistribution) throws AbortException {
-        logger.log(Messages.Builder_Threshold_ComparingTo(previousDistribution.getBuildNumber()));
+        if (previousDistribution != null) {
+            logger.log(Messages.Builder_Threshold_ComparingTo(previousDistribution.getBuildNumber()));
+        } else {
+            logger.log(Messages.Builder_Threshold_NoComparison());
+        }
         final RiskGate riskGate = new RiskGate(getThresholds());
         final Result result = riskGate.evaluate(currentDistribution, previousDistribution);
         if (result.isWorseOrEqualTo(Result.UNSTABLE) && result.isCompleteBuild()) {

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/RiskGate.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/RiskGate.java
@@ -40,7 +40,7 @@ public class RiskGate implements Serializable {
      * @param previousDistribution previousDistribution
      * @return a Result
      */
-    public Result evaluate(@NonNull final SeverityDistribution currentDistribution, @NonNull final SeverityDistribution previousDistribution) {
+    public Result evaluate(@NonNull final SeverityDistribution currentDistribution, final SeverityDistribution previousDistribution) {
 
         Result result = Result.SUCCESS;
         if ((thresholds.totalFindings.failedCritical != null && currentDistribution.getCritical() > 0 && currentDistribution.getCritical() >= thresholds.totalFindings.failedCritical)
@@ -57,22 +57,24 @@ public class RiskGate implements Serializable {
 
             result = Result.UNSTABLE;
         }
+        
+        if (previousDistribution != null) {
+            if ((thresholds.newFindings.failedCritical != null && currentDistribution.getCritical() > 0 && currentDistribution.getCritical() >= previousDistribution.getCritical() + thresholds.newFindings.failedCritical)
+                    || (thresholds.newFindings.failedHigh != null && currentDistribution.getHigh() > 0 && currentDistribution.getHigh() >= previousDistribution.getHigh() + thresholds.newFindings.failedHigh)
+                    || (thresholds.newFindings.failedMedium != null && currentDistribution.getMedium() > 0 && currentDistribution.getMedium() >= previousDistribution.getMedium() + thresholds.newFindings.failedMedium)
+                    || (thresholds.newFindings.failedLow != null && currentDistribution.getLow() > 0 && currentDistribution.getLow() >= previousDistribution.getLow() + thresholds.newFindings.failedLow)) {
 
-        if ((thresholds.newFindings.failedCritical != null && currentDistribution.getCritical() > 0 && currentDistribution.getCritical() >= previousDistribution.getCritical() + thresholds.newFindings.failedCritical)
-                || (thresholds.newFindings.failedHigh != null && currentDistribution.getHigh() > 0 && currentDistribution.getHigh() >= previousDistribution.getHigh() + thresholds.newFindings.failedHigh)
-                || (thresholds.newFindings.failedMedium != null && currentDistribution.getMedium() > 0 && currentDistribution.getMedium() >= previousDistribution.getMedium() + thresholds.newFindings.failedMedium)
-                || (thresholds.newFindings.failedLow != null && currentDistribution.getLow() > 0 && currentDistribution.getLow() >= previousDistribution.getLow() + thresholds.newFindings.failedLow)) {
+                return Result.FAILURE;
+            }
+            if ((thresholds.newFindings.unstableCritical != null && currentDistribution.getCritical() > 0 && currentDistribution.getCritical() >= previousDistribution.getCritical() + thresholds.newFindings.unstableCritical)
+                    || (thresholds.newFindings.unstableHigh != null && currentDistribution.getHigh() > 0 && currentDistribution.getHigh() >= previousDistribution.getHigh() + thresholds.newFindings.unstableHigh)
+                    || (thresholds.newFindings.unstableMedium != null && currentDistribution.getMedium() > 0 && currentDistribution.getMedium() >= previousDistribution.getMedium() + thresholds.newFindings.unstableMedium)
+                    || (thresholds.newFindings.unstableLow != null && currentDistribution.getLow() > 0 && currentDistribution.getLow() >= previousDistribution.getLow() + thresholds.newFindings.unstableLow)) {
 
-            return Result.FAILURE;
+                result = Result.UNSTABLE;
+            }
         }
-        if ((thresholds.newFindings.unstableCritical != null && currentDistribution.getCritical() > 0 && currentDistribution.getCritical() >= previousDistribution.getCritical() + thresholds.newFindings.unstableCritical)
-                || (thresholds.newFindings.unstableHigh != null && currentDistribution.getHigh() > 0 && currentDistribution.getHigh() >= previousDistribution.getHigh() + thresholds.newFindings.unstableHigh)
-                || (thresholds.newFindings.unstableMedium != null && currentDistribution.getMedium() > 0 && currentDistribution.getMedium() >= previousDistribution.getMedium() + thresholds.newFindings.unstableMedium)
-                || (thresholds.newFindings.unstableLow != null && currentDistribution.getLow() > 0 && currentDistribution.getLow() >= previousDistribution.getLow() + thresholds.newFindings.unstableLow)) {
-
-            result = Result.UNSTABLE;
-        }
-
+    
         return result;
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages.properties
@@ -45,6 +45,7 @@ Builder.Project.Update=Updating project properties
 Builder.Findings.Processing=Processing findings
 Builder.Threshold.Exceed=Findings exceed configured thresholds
 Builder.Threshold.ComparingTo=Evaluating new findings against previous build #{0}
+Builder.Threshold.NoComparison=This is the first build. Findings will not be compared to a previous build.
 Builder.Upload.Failed=Uploading artifact failed
 Builder.Connection.Failed=Could not connect to Dependency-Track. Please check the plugin configuration.
 

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages_de.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages_de.properties
@@ -45,6 +45,7 @@ Builder.Project.Update=Aktualisiere Projekt-Eigenschaften
 Builder.Findings.Processing=Verarbeite Ergebnisse
 Builder.Threshold.Exceed=Ergebnisse \u00fcberschreiten konfigurierte Schwellwerte
 Builder.Threshold.ComparingTo=Bewerte neue Ergebnisse im Vergleich zu fr\u00fcherem Lauf #{0}
+Builder.Threshold.NoComparison=Dies ist der erste Lauf. Die Ergebnisse werden nicht mit einem fr\u00fcheren Lauf verglichen.
 Builder.Upload.Failed=Hochladen des Artefakts fehlgeschlagen
 Builder.Connection.Failed=Es konnte keine Verbindung mit Dependency-Track hergestellt werden! Bitte pr\u00fcfen Sie die Plugin-Konfiguration.
 


### PR DESCRIPTION
We are using this plugin with only the newFindings thresholds. By default this plugin has the side effect to interrupt the first build as it creates a distribution with 0 vulnerability if there's no previous build. I don't see the point to have this behaviour.

The purpose of this PR is to ignore the newFindings checks for the first build in Jenkins. This has no effect if totalFindings thresholds are used.

We've tested succesfully in our Jenkins instance. If you think that this PR is appropriate I will update the changelog file.
<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
