### PR TITLE
Remove usages of `l:css`

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config.jelly
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:l="/lib/layout">
-    <l:css src="plugin/dependency-track/css/config.css" />
+    <link rel="stylesheet" href="${rootURL}/plugin/dependency-track/css/config.css" type="text/css" />
 
     <f:section title="${%publishToDependencytrack}">
         <f:entry title="${%projectId}" field="projectId">

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/global.jelly
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-    <l:css src="plugin/dependency-track/css/global.css" />
+    <link rel="stylesheet" href="${rootURL}/plugin/dependency-track/css/global.css" type="text/css" />
 
     <f:section title="Dependency-Track">
         <f:entry title="${%dependencytrack.url}" field="dependencyTrackUrl">


### PR DESCRIPTION
Does not require https://github.com/jenkinsci/jenkins/pull/7827, but needed before https://github.com/jenkinsci/jenkins/pull/7827 can be merged and released. To test this PR, I created a Freestyle project and added a Dependency-Track publisher, then verified that the `config.css` was properly loaded in my browser's network debugging tools; similarly, I verified that `global.css` was correctly loaded from the Manage Jenkins page. A timely merge and release of this PR would be of great assistance to the core developers with regard to unblocking https://github.com/jenkinsci/jenkins/pull/7827 and facilitating the removal of an undesirable dependency from Jenkins core. CC @sephiroth-j