### PR TITLE
Added the possibility to assign projects to a team/portfolio, backported to branch 4.3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ VULNERABILITY_ANALYSIS | :ballot_box_with_check: | needed to perform dependency 
 PROJECT_CREATION_UPLOAD | :grey_question: | needed to create non-existing projects during BOM upload
 VIEW_VULNERABILITY | :grey_question: | needed in synchronous publishing mode to retrieve analysis results
 PORTFOLIO_MANAGEMENT | :grey_question: | needed for updating project properties such as tags
+ACCESS_MANAGEMENT | :grey_question: | needed to map the project to a team-portfolio (currently still in beta in Dependeny-Track)
 
 ## Job Configuration
 Once configured with a valid URL and API key, simply configure a job to publish the artifact.
@@ -63,6 +64,8 @@ Once configured with a valid URL and API key, simply configure a job to publish 
 **Dependency-Track project name**: Specifies the name of the project for automatic creation of project during the upload process. This is an alternative to specifying the unique ID. It must be used together with a project version. Only avaible if "Auto Create projects" is enabled. The use of environment variables in the form `${VARIABLE}` is supported here.
 
 **Dependency-Track project version**: Specifies the version of the project for automatic creation of project during the upload process. This is an alternative to specifying the unique ID. It must be used together with a project name. Only avaible if "Auto Create projects" is enabled. The use of environment variables in the form `${VARIABLE}` is supported here.
+
+**Team-Name:** Specifies the name of the team to whose portfolio the project should be added. The provided API key requires the `ACCESS_MANAGEMENT` permission to use this feature!
 
 **Artifact:** Specifies the file to upload. Paths are relative from the Jenkins workspace. The use of environment variables in the form `${VARIABLE}` is supported here.
 

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
@@ -82,6 +82,11 @@ public final class DependencyTrackPublisher extends Recorder implements SimpleBu
     private final String artifact;
 
     /**
+     * Name of the team to map the project to. This is a per-build config item.
+     */
+    private String teamName;
+
+    /**
      * Retrieves whether synchronous mode is enabled or not. This is a per-build
      * config item.
      */
@@ -279,6 +284,16 @@ public final class DependencyTrackPublisher extends Recorder implements SimpleBu
         logger.log(Messages.Builder_Success(String.format("%s/projects/%s", getEffectiveFrontendUrl(), StringUtils.isNotBlank(projectId) ? projectId : StringUtils.EMPTY)));
         
         updateProjectProperties(logger, apiClient, effectiveProjectName, effectiveProjectVersion);
+
+        if (!StringUtils.isBlank(teamName)) {
+            String teamUuid = apiClient.lookupTeam(teamName);
+            if (teamUuid == null) {
+                logger.log(Messages.Builder_Team_NotFound(teamName));
+            } else {
+                apiClient.mapProjectToTeam(lookupProjectId(logger, apiClient, effectiveProjectName, effectiveProjectVersion), teamUuid);
+                logger.log(Messages.Builder_Team_Assigned(teamName));
+            }
+        }
 
         if (synchronous && StringUtils.isNotBlank(uploadResult.getToken())) {
             publishAnalysisResult(logger, apiClient, uploadResult.getToken(), run, effectiveProjectName, effectiveProjectVersion);

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config.jelly
@@ -35,6 +35,10 @@ limitations under the License.
             <f:textbox id="artifact"/>
         </f:entry>
 
+        <f:entry title="${%teamName}" field="teamName">
+            <f:textbox id="teamName"/>
+        </f:entry>
+
         <f:entry title="${%enable.synchronous}" field="synchronous">
             <f:checkbox name="synchronous" checked="${instance.isSynchronous()}"/>
         </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config.properties
@@ -18,6 +18,7 @@ projectName=Dependency-Track project name
 projectVersion=Dependency-Track project version
 projectProperties=Update project properties
 artifact=Artifact
+teamName=Team name
 enable.synchronous=Enable synchronous publishing mode
 dependencytrack.url=Dependency-Track Backend URL
 dependencytrack.url.frontend=Dependency-Track Frontend URL

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config_de.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/config_de.properties
@@ -18,6 +18,7 @@ projectName=Dependency-Track Projektname
 projectVersion=Dependency-Track Projektversion
 projectProperties=Projekteigenschaften setzen
 artifact=Artefakt
+teamName=Name des Teams
 enable.synchronous=Synchronen Ver\u00f6ffentlichungsmodus aktivieren
 dependencytrack.url=Dependency-Track Backend URL
 dependencytrack.url.frontend=Dependency-Track Frontend URL

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/help-teamName.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/help-teamName.html
@@ -1,0 +1,5 @@
+<div>
+    Specifies the name of the team to which the project should be mapped during the upload process.
+    <p>Ensure the API key specified in the global configuration has ACCESS_MANAGEMENT permission.</p>
+    <p>The value can contain environment variables in the form of <code>${VARIABLE_NAME}</code> which are resolved.</p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/help-teamName_de.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/help-teamName_de.html
@@ -1,0 +1,5 @@
+<div>
+    Gibt den Teamnamen an, an welcher das Projekt zugewiesen werden soll.
+    <p>Stellen Sie sicher, dass der verwendete API-Schlüssel die Berechtigung "ACCESS_MANAGEMENT" bestitzt.</p>
+    <p>Der Wert kann Umgebungsvariablen in Form von <code>${VARIABLE_NAME}</code> enthalten, die aufgelöst werden.</p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages.properties
@@ -45,6 +45,8 @@ Builder.Threshold.Exceed=Findings exceed configured thresholds
 Builder.Threshold.ComparingTo=Evaluating new findings against previous build #{0}
 Builder.Upload.Failed=Uploading artifact failed
 Builder.Connection.Failed=Could not connect to Dependency-Track. Please check the plugin configuration.
+Builder.Team.Assigned=Project was assigned to team "{0}"
+Builder.Team.NotFound=Team with name "{0}" was not found, so no assignment was possible
 
 ApiClient.Error.Connection=An error occurred connecting to Dependency-Track - HTTP response code: {0} {1}
 ApiClient.Error.TokenProcessing=An error occurred while checking if a token is being processed - HTTP response code: {0} {1}

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages_de.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages_de.properties
@@ -45,6 +45,8 @@ Builder.Threshold.Exceed=Ergebnisse \u00fcberschreiten konfigurierte Schwellwert
 Builder.Threshold.ComparingTo=Bewerte neue Ergebnisse im Vergleich zu fr\u00fcherem Lauf #{0}
 Builder.Upload.Failed=Hochladen des Artefakts fehlgeschlagen
 Builder.Connection.Failed=Es konnte keine Verbindung mit Dependency-Track hergestellt werden! Bitte pr\u00fcfen Sie die Plugin-Konfiguration.
+Builder.Team.Assigned=Projekt wurde an Team "{0}" zugewiesen
+Builder.Team.NotFound=Team mit name "{0}" konnte icht gefunden werden, daher ist kein Zuweisung m\u00d6glich
 
 ApiClient.Error.Connection=Verbindungsfehler mit Dependency-Track - HTTP-Antwortcode: {0} {1}
 ApiClient.Error.TokenProcessing=Bei der Pr\u00fcfung, ob ein Token verarbeitet wird, ist ein Fehler aufgetreten - HTTP-Antwortcode: {0} {1}

--- a/src/test/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisherTest.java
@@ -323,4 +323,72 @@ public class DependencyTrackPublisherTest {
         }
     }
 
+    @Test
+    public void testPerformSyncWithoutTeamAssignment() throws IOException, InterruptedException {
+        File tmp = tmpDir.newFile();
+        FilePath workDir = new FilePath(tmpDir.getRoot());
+        DependencyTrackPublisher uut = new DependencyTrackPublisher(tmp.getName(), true, clientFactory);
+        uut.setProjectName("name-1");
+        uut.setProjectVersion("version-1");
+        uut.setDependencyTrackApiKey(apikeyId);
+        uut.setAutoCreateProjects(Boolean.TRUE);
+        uut.setProjectProperties(new ProjectProperties());
+
+        when(client.upload(isNull(), eq("name-1"), eq("version-1"), any(FilePath.class), eq(true))).thenReturn(new UploadResult(true, "token-1"));
+        when(client.isTokenBeingProcessed("token-1")).thenReturn(Boolean.TRUE).thenReturn(Boolean.FALSE);
+        when(client.getFindings("uuid-1")).thenReturn(Collections.emptyList());
+        when(client.lookupProject("name-1", "version-1")).thenReturn(Project.builder().uuid("uuid-1").build());
+        when(client.lookupTeam("team-1")).thenReturn("team-1-uuid");
+
+        assertThatCode(() -> uut.perform(build, workDir, env, launcher, listener)).doesNotThrowAnyException();
+        verify(client, times(0)).lookupTeam("team-1");
+        verify(client, times(0)).mapProjectToTeam(any(), any());
+    }
+
+    @Test
+    public void testPerformSyncWithExistingTeamAssignment() throws IOException, InterruptedException {
+        File tmp = tmpDir.newFile();
+        FilePath workDir = new FilePath(tmpDir.getRoot());
+        DependencyTrackPublisher uut = new DependencyTrackPublisher(tmp.getName(), true, clientFactory);
+        uut.setProjectName("name-1");
+        uut.setProjectVersion("version-1");
+        uut.setDependencyTrackApiKey(apikeyId);
+        uut.setAutoCreateProjects(Boolean.TRUE);
+        uut.setProjectProperties(new ProjectProperties());
+        uut.setTeamName("team-1");
+
+        when(client.upload(isNull(), eq("name-1"), eq("version-1"), any(FilePath.class), eq(true))).thenReturn(new UploadResult(true, "token-1"));
+        when(client.isTokenBeingProcessed("token-1")).thenReturn(Boolean.TRUE).thenReturn(Boolean.FALSE);
+        when(client.getFindings("uuid-1")).thenReturn(Collections.emptyList());
+        when(client.lookupProject("name-1", "version-1")).thenReturn(Project.builder().uuid("uuid-1").build());
+        when(client.lookupTeam("team-1")).thenReturn("team-1-uuid");
+
+        assertThatCode(() -> uut.perform(build, workDir, env, launcher, listener)).doesNotThrowAnyException();
+        verify(client).lookupTeam("team-1");
+        verify(client).mapProjectToTeam(any(), any());
+    }
+
+    @Test
+    public void testPerformSyncWithNonExistingTeamAssignment() throws IOException, InterruptedException {
+        File tmp = tmpDir.newFile();
+        FilePath workDir = new FilePath(tmpDir.getRoot());
+        DependencyTrackPublisher uut = new DependencyTrackPublisher(tmp.getName(), true, clientFactory);
+        uut.setProjectName("name-1");
+        uut.setProjectVersion("version-1");
+        uut.setDependencyTrackApiKey(apikeyId);
+        uut.setAutoCreateProjects(Boolean.TRUE);
+        uut.setProjectProperties(new ProjectProperties());
+        uut.setTeamName("team-1");
+
+        when(client.upload(isNull(), eq("name-1"), eq("version-1"), any(FilePath.class), eq(true))).thenReturn(new UploadResult(true, "token-1"));
+        when(client.isTokenBeingProcessed("token-1")).thenReturn(Boolean.TRUE).thenReturn(Boolean.FALSE);
+        when(client.getFindings("uuid-1")).thenReturn(Collections.emptyList());
+        when(client.lookupProject("name-1", "version-1")).thenReturn(Project.builder().uuid("uuid-1").build());
+        when(client.lookupTeam("team-1")).thenReturn(null);
+
+        assertThatCode(() -> uut.perform(build, workDir, env, launcher, listener)).doesNotThrowAnyException();
+        verify(client).lookupTeam("team-1");
+        verify(client, times(0)).mapProjectToTeam(any(), any());
+    }
+
 }


### PR DESCRIPTION
This PR implements issue #162, by adding a new field in the UI that takes the name of a team to which a project is to be assigned when uploading BOM data.

- Changes in UI added
- Help texts added
- Translation in German added (not a native speaker, so some small grammar issues might exist)
- Documentation added

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Effectively this is the same as #163, only on the 4.3.x branch, seeing the master had some issues when I deployed a build on my jenkins!