### PR TITLE
Support for specifying the parent project using its name and version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### ⚠ Breaking
 ### ⭐ New Features
+- Support for specifying the parent project using its name and version as an alternative to its ID (fixes [#261](https://github.com/jenkinsci/dependency-track-plugin/issues/261))
+
 ### 🐞 Bugs Fixed
 
 ## v5.0.0 - 2024-05-30

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/ProjectProperties.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/ProjectProperties.java
@@ -81,6 +81,18 @@ public final class ProjectProperties extends AbstractDescribableImpl<ProjectProp
     @Nullable
     private String parentId;
 
+    /**
+     * Name of the parent project
+     */
+    @Nullable
+    private String parentName;
+
+    /**
+     * Version of the parent project
+     */
+    @Nullable
+    private String parentVersion;
+
     @NonNull
     public List<String> getTags() {
         return normalizeTags(tags);
@@ -132,6 +144,16 @@ public final class ProjectProperties extends AbstractDescribableImpl<ProjectProp
     @DataBoundSetter
     public void setParentId(final String parentId) {
         this.parentId = StringUtils.trimToNull(parentId);
+    }
+
+    @DataBoundSetter
+    public void setParentName(final String parentName) {
+        this.parentName = StringUtils.trimToNull(parentName);
+    }
+
+    @DataBoundSetter
+    public void setParentVersion(final String parentVersion) {
+        this.parentVersion = StringUtils.trimToNull(parentVersion);
     }
 
     @NonNull

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/config.jelly
@@ -31,5 +31,11 @@ limitations under the License.
     <f:entry field="parentId" title="${%parentId}">
         <f:select id="parentId"/>
     </f:entry>
+    <f:entry field="parentName" title="${%parentName}">
+        <f:textbox id="parentName" />
+    </f:entry>
+    <f:entry field="parentVersion" title="${%parentVersion}">
+        <f:textbox id="parentVersion" />
+    </f:entry>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/config.properties
@@ -17,3 +17,5 @@ swidTagId=SWID Tag ID
 group=Namespace / Group / Vendor
 description=Description
 parentId=Parent project
+parentName=Parent name
+parentVersion=Parent version

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/config_de.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/config_de.properties
@@ -17,3 +17,5 @@ swidTagId=SWID Tag ID
 group=Namensraum / Gruppe / Hersteller
 description=Beschreibung
 parentId=\u00dcbergeordnetes Projekt
+parentName=Name des \u00fcbergeordneten Projekts
+parentVersion=Version des \u00fcbergeordneten Projekts

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentId_de.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentId_de.html
@@ -1,3 +1,3 @@
 <div>
-    Die ID (UUID) des übergeordneten Projektes.
+    Die ID (UUID) des übergeordneten Projekts.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentName.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentName.html
@@ -1,0 +1,3 @@
+<div>
+    The name of the parent project.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentName_de.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentName_de.html
@@ -1,0 +1,3 @@
+<div>
+    Der Name des übergeordneten Projekts.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentVersion.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentVersion.html
@@ -1,0 +1,3 @@
+<div>
+    The version of the parent project.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentVersion_de.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentVersion_de.html
@@ -1,0 +1,3 @@
+<div>
+    Die Version des übergeordneten Projekts.
+</div>


### PR DESCRIPTION
The name and the version of the parent project can now be specified as an alternative to its ID.

closes #261
