### PR TITLE
Support variables in project properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### ⚠ Breaking
 ### ⭐ New Features
+- Support variables in project properties ([JENKINS-74822](https://issues.jenkins.io/browse/JENKINS-74822))
+
 ### 🐞 Bugs Fixed
 
 ## v5.1.0 - 2024-09-20

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Once configured with a valid URL and API key, simply configure a job to publish 
 - description
 - ID of parent project (for Dependency-Track v4.7 and newer)
 
+ The use of environment variables in the form `${VARIABLE}` is supported here.
+
 **Override global settings**: Allows to override global settings for "Auto Create Projects", "Dependency-Track URL", "Dependency-Track Frontend URL", "API key", "Polling Interval" and the various timeouts.
 
 ### Thresholds

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-description.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-description.html
@@ -1,3 +1,4 @@
 <div>
     The description to be set for the project.
+    <p>The value can contain environment variables in the form of <code>${VARIABLE_NAME}</code> which are resolved.</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-description_de.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-description_de.html
@@ -1,3 +1,4 @@
 <div>
     Die Beschreibung, die für das Projekt gesetzt werden soll.
+    <p>Der Wert kann Umgebungsvariablen in Form von <code>${VARIABLE_NAME}</code> enthalten, die aufgelöst werden.</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-group.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-group.html
@@ -1,3 +1,4 @@
 <div>
     Specifies the value of "Namespace / Group / Vendor" to be set for the project.
+    <p>The value can contain environment variables in the form of <code>${VARIABLE_NAME}</code> which are resolved.</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-group_de.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-group_de.html
@@ -1,3 +1,4 @@
 <div>
     Wert für "Namensraum / Gruppe / Hersteller", der für das Projekt gesetzt werden soll.
+    <p>Der Wert kann Umgebungsvariablen in Form von <code>${VARIABLE_NAME}</code> enthalten, die aufgelöst werden.</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentId.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentId.html
@@ -1,3 +1,4 @@
 <div>
     The ID (UUID) of the parent project.
+    <p>The value can contain environment variables in the form of <code>${VARIABLE_NAME}</code> which are resolved.</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentId_de.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentId_de.html
@@ -1,3 +1,4 @@
 <div>
     Die ID (UUID) des übergeordneten Projekts.
+    <p>Der Wert kann Umgebungsvariablen in Form von <code>${VARIABLE_NAME}</code> enthalten, die aufgelöst werden.</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentName.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentName.html
@@ -1,3 +1,4 @@
 <div>
     The name of the parent project.
+    <p>The value can contain environment variables in the form of <code>${VARIABLE_NAME}</code> which are resolved.</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentName_de.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentName_de.html
@@ -1,3 +1,4 @@
 <div>
     Der Name des übergeordneten Projekts.
+    <p>Der Wert kann Umgebungsvariablen in Form von <code>${VARIABLE_NAME}</code> enthalten, die aufgelöst werden.</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentVersion.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentVersion.html
@@ -1,3 +1,4 @@
 <div>
     The version of the parent project.
+    <p>The value can contain environment variables in the form of <code>${VARIABLE_NAME}</code> which are resolved.</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentVersion_de.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-parentVersion_de.html
@@ -1,3 +1,4 @@
 <div>
     Die Version des übergeordneten Projekts.
+    <p>Der Wert kann Umgebungsvariablen in Form von <code>${VARIABLE_NAME}</code> enthalten, die aufgelöst werden.</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-swidTagId.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-swidTagId.html
@@ -1,3 +1,4 @@
 <div>
     Specifies the SWID Tag ID to be set for the project.
+    <p>The value can contain environment variables in the form of <code>${VARIABLE_NAME}</code> which are resolved.</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-swidTagId_de.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-swidTagId_de.html
@@ -1,3 +1,4 @@
 <div>
     Wert für "SWID Tag ID", der für das Projekt gesetzt werden soll.
+    <p>Der Wert kann Umgebungsvariablen in Form von <code>${VARIABLE_NAME}</code> enthalten, die aufgelöst werden.</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-tags.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-tags.html
@@ -1,4 +1,5 @@
 <div>
     Specifies the list of tags to be set for the project. Separate multiple tags with spaces or put each tag on a separate line.
     <p>All tags are automatically lowercased!</p>
+    <p>The tag-value can contain environment variables in the form of <code>${VARIABLE_NAME}</code> which are resolved.</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-tags_de.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-tags_de.html
@@ -1,4 +1,5 @@
 <div>
     Gibt die Liste der Tags an, die für das Projekt gesetzt werden sollen. Trennen Sie mehrere Tags durch Leerzeichen oder eine eigene Zeile.
     <p>Alle Tags werden automatisch kleingeschrieben!</p>
+    <p>Der Tag-Wert kann Umgebungsvariablen in Form von <code>${VARIABLE_NAME}</code> enthalten, die aufgelöst werden.</p>
 </div>


### PR DESCRIPTION
The use of environment variables in the form `${VARIABLE}` is now supported everywhere in project properties.

fixes [JENKINS-74822](https://issues.jenkins.io/browse/JENKINS-74822)
