### PR TITLE
use jenkins release-repo instead of public-repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,34 +97,6 @@
             </build>
         </profile>
         <profile>
-            <id>add-central-repo</id>
-            <activation>
-                <property>
-                    <name>!env.JENKINS_URL</name>
-                </property>
-            </activation>
-            <repositories>
-                <repository>
-                    <id>central</id>
-                    <name>Central Repository</name>
-                    <url>https://repo.maven.apache.org/maven2</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>central</id>
-                    <name>Central Repository</name>
-                    <url>https://repo.maven.apache.org/maven2</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
-        </profile>
-        <profile>
             <id>update-changelog</id>
             <build>
                 <plugins>
@@ -558,14 +530,14 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/releases/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/releases/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
-                    <version>4.0.0.4121</version>
+                    <version>5.0.0.4389</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -284,7 +284,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>npm install</id>
@@ -470,7 +470,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.34</version>
+            <version>1.18.36</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -524,7 +524,7 @@
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty</artifactId>
-            <version>[1.1.0,1.1.99)</version>
+            <version>[1.1.0,1.2.99)</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
>  Artifacts that should be retrieved from Apache Maven Central are instead being retrieved from the Artifactory repository provided to Jenkins by JFrog. That creates unexpected load on the Artifactory repository and risks that JFrog will have unexpected bandwidth costs for our Artifactory instance.

jenkins-infra/helpdesk/issues/4385