### PR TITLE
support isLatest flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 ### ⚠ Breaking
 - require Jenkins 2.479.1 or newer
 - require Java 17 or newer (required since Jenkins 2.479.1)
+- require Dependency-Track 4.12 or newer ([#286](https://github.com/jenkinsci/dependency-track-plugin/issues/286))
 
 ### ⭐ New Features
+- Support "isLatest" flag ([#286](https://github.com/jenkinsci/dependency-track-plugin/issues/286))
+
 ### 🐞 Bugs Fixed
 
 ## v5.2.0 - 2024-12-08

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Asynchronous publishing simply uploads the SBOM to Dependency-Track and the job 
 ![build summary](docs/images/jenkins-build-summary.png)
 ![findings](docs/images/jenkins-build-findings.png) ![policy violations](docs/images/jenkins-build-policy-violations.png)
 
+## Version Compatibility Matrix
+Plugin Version | Dependency-Track | Jenkins | Java
+---------------| ---------------- | ------- | ----
+6.0.x (next) | 4.12+ | 2.479.1+ | 17+
+5.2.x (current) | 4.9+ | 2.440.1+ | 11+
+
 ## Global Configuration
 To setup, navigate to Jenkins > System Configuration and complete the Dependency-Track section.
 
@@ -75,7 +81,9 @@ Once configured with a valid URL and API key, simply configure a job to publish 
 - SWID tag ID
 - group/vendor
 - description
-- ID of parent project (for Dependency-Track v4.7 and newer)
+- ID of parent project
+- name and version of parent project (as an alternative to the ID)
+- "is latest version" flag
 
  The use of environment variables in the form `${VARIABLE}` is supported here.
 

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
@@ -322,8 +322,8 @@ public final class DependencyTrackPublisher extends Recorder implements SimpleBu
         final ProjectProperties effectiveProjectProperties = expandProjectProperties(env);
         logger.log(Messages.Builder_Publishing(effectiveUrl, effectiveArtifact));
         final ApiClient apiClient = clientFactory.create(effectiveUrl, effectiveApiKey, logger, getEffectiveConnectionTimeout(), getEffectiveReadTimeout());
-        final UploadResult uploadResult = apiClient.upload(projectId, effectiveProjectName, effectiveProjectVersion,
-                artifactFilePath, effectiveAutocreate, effectiveProjectProperties);
+        final var projectData = new ApiClient.ProjectData(projectId, effectiveProjectName, effectiveProjectVersion, effectiveAutocreate, effectiveProjectProperties);
+        final UploadResult uploadResult = apiClient.upload(projectData, artifactFilePath);
 
         if (!uploadResult.isSuccess()) {
             throw new AbortException(Messages.Builder_Upload_Failed());
@@ -615,6 +615,7 @@ public final class DependencyTrackPublisher extends Recorder implements SimpleBu
                 projectProperties.getDescription() != null
                 || projectProperties.getGroup() != null
                 || projectProperties.getSwidTagId() != null
+                || projectProperties.getIsLatest() != null
                 || !projectProperties.getTags().isEmpty());
 
         if (doUpdateProject) {
@@ -646,6 +647,7 @@ public final class DependencyTrackPublisher extends Recorder implements SimpleBu
             Optional.ofNullable(projectProperties.getParentVersion()).map(env::expand).ifPresent(expandedProperties::setParentVersion);
             Optional.ofNullable(projectProperties.getSwidTagId()).map(env::expand).ifPresent(expandedProperties::setSwidTagId);
             expandedProperties.setTags(projectProperties.getTags().stream().map(env::expand).toList());
+            expandedProperties.setIsLatest(projectProperties.getIsLatest());
             return expandedProperties;
         }
         return null;

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DescriptorImpl.java
@@ -273,7 +273,7 @@ public class DescriptorImpl extends BuildStepDescriptor<Publisher> implements Se
                     return FormValidation.error(Messages.Publisher_ConnectionTest_Error(poweredBy));
                 }
                 final VersionNumber version = apiClient.getVersion();
-                final var requiredVersion = new VersionNumber("4.9.0");
+                final var requiredVersion = new VersionNumber("4.12.0");
                 if (version.isOlderThan(requiredVersion)) {
                     return FormValidation.error(Messages.Publisher_ConnectionTest_VersionWarning(version, requiredVersion));
                 }

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/ProjectProperties.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/ProjectProperties.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 import jenkins.model.Jenkins;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -92,6 +93,13 @@ public final class ProjectProperties extends AbstractDescribableImpl<ProjectProp
      */
     @Nullable
     private String parentVersion;
+
+    /**
+     * Mark this version of the project as the latest version
+     */
+    @Nullable
+    @Setter(onMethod_ = {@DataBoundSetter})
+    private Boolean isLatest;
 
     @NonNull
     public List<String> getTags() {

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/config.jelly
@@ -28,6 +28,9 @@ limitations under the License.
     <f:entry field="description" title="${%description}">
         <f:textbox id="description" />
     </f:entry>
+    <f:entry field="isLatest" title="${%isLatest}">
+        <f:checkbox id="isLatest" />
+    </f:entry>
     <f:entry field="parentId" title="${%parentId}">
         <f:select id="parentId"/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/config.properties
@@ -19,3 +19,4 @@ description=Description
 parentId=Parent project
 parentName=Parent name
 parentVersion=Parent version
+isLatest=Is latest version

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/config_de.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/config_de.properties
@@ -19,3 +19,4 @@ description=Beschreibung
 parentId=\u00dcbergeordnetes Projekt
 parentName=Name des \u00fcbergeordneten Projekts
 parentVersion=Version des \u00fcbergeordneten Projekts
+isLatest=Ist aktuellste Version

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-isLatest.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-isLatest.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Marks this version of the project as the latest.</p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-isLatest_de.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/ProjectProperties/help-isLatest_de.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Markiert diese Version des Projekts als die neueste.</p>
+</div>

--- a/src/test/java/org/jenkinsci/plugins/DependencyTrack/DescriptorImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyTrack/DescriptorImplTest.java
@@ -143,7 +143,7 @@ class DescriptorImplTest {
 
             assertThat(uut.doTestConnectionGlobal("http:///url.tld", credentialsid, false, null))
                     .hasFieldOrPropertyWithValue("kind", FormValidation.Kind.ERROR)
-                    .hasMessage(Messages.Publisher_ConnectionTest_VersionWarning("3.8.0", "4.9.0"))
+                    .hasMessage(Messages.Publisher_ConnectionTest_VersionWarning("3.8.0", "4.12.0"))
                     .hasNoCause();
 
             assertThat(uut.doTestConnectionGlobal("http:///url.tld/", credentialsid, false, null))
@@ -196,8 +196,8 @@ class DescriptorImplTest {
             assertThat(logger).isInstanceOf(ConsoleLogger.class);
             return client;
         };
-        when(client.testConnection()).thenReturn("Dependency-Track v4.9.0");
-        when(client.getVersion()).thenReturn(new VersionNumber("4.9.0"));
+        when(client.testConnection()).thenReturn("Dependency-Track v4.12.0");
+        when(client.getVersion()).thenReturn(new VersionNumber("4.12.0"));
         when(client.getTeamPermissions()).thenReturn(Team.builder().name("my-team").permissions(requiredPermissions).build());
         try (ACLContext ignored = ACL.as(User.getOrCreateByIdOrFullName(ACL.SYSTEM_USERNAME))) {
             CredentialsProvider.lookupStores(r.jenkins).iterator().next().addCredentials(Domain.global(), new StringCredentialsImpl(CredentialsScope.GLOBAL, credentialsid, "test", Secret.fromString(apikey)));
@@ -226,9 +226,9 @@ class DescriptorImplTest {
             assertThat(logger).isInstanceOf(ConsoleLogger.class);
             return client;
         };
-        final var poweredBy = "Dependency-Track v4.9.0";
+        final var poweredBy = "Dependency-Track v4.12.0";
         when(client.testConnection()).thenReturn(poweredBy);
-        when(client.getVersion()).thenReturn(new VersionNumber("4.9.0"));
+        when(client.getVersion()).thenReturn(new VersionNumber("4.12.0"));
         when(client.getTeamPermissions()).thenReturn(team);
         try (ACLContext ignored = ACL.as(User.getOrCreateByIdOrFullName(ACL.SYSTEM_USERNAME))) {
             CredentialsProvider.lookupStores(r.jenkins).iterator().next().addCredentials(Domain.global(), new StringCredentialsImpl(CredentialsScope.GLOBAL, credentialsid, "test", Secret.fromString(apikey)));
@@ -266,9 +266,9 @@ class DescriptorImplTest {
             assertThat(logger).isInstanceOf(ConsoleLogger.class);
             return client;
         };
-        final var poweredBy = "Dependency-Track v4.9.0";
+        final var poweredBy = "Dependency-Track v4.12.0";
         when(client.testConnection()).thenReturn(poweredBy);
-        when(client.getVersion()).thenReturn(new VersionNumber("4.9.0"));
+        when(client.getVersion()).thenReturn(new VersionNumber("4.12.0"));
         when(client.getTeamPermissions()).thenReturn(team);
         try (ACLContext ignored = ACL.as(User.getOrCreateByIdOrFullName(ACL.SYSTEM_USERNAME))) {
             CredentialsProvider.lookupStores(r.jenkins).iterator().next().addCredentials(Domain.global(), new StringCredentialsImpl(CredentialsScope.GLOBAL, credentialsid, "test", Secret.fromString(apikey)));
@@ -306,9 +306,9 @@ class DescriptorImplTest {
             assertThat(logger).isInstanceOf(ConsoleLogger.class);
             return client;
         };
-        final var poweredBy = "Dependency-Track v4.9.0";
+        final var poweredBy = "Dependency-Track v4.12.0";
         when(client.testConnection()).thenReturn(poweredBy);
-        when(client.getVersion()).thenReturn(new VersionNumber("4.9.0"));
+        when(client.getVersion()).thenReturn(new VersionNumber("4.12.0"));
         when(client.getTeamPermissions()).thenReturn(team);
         try (ACLContext ignored = ACL.as(User.getOrCreateByIdOrFullName(ACL.SYSTEM_USERNAME))) {
             CredentialsProvider.lookupStores(r.jenkins).iterator().next().addCredentials(Domain.global(), new StringCredentialsImpl(CredentialsScope.GLOBAL, credentialsid, "test", Secret.fromString(apikey)));

--- a/src/test/java/org/jenkinsci/plugins/DependencyTrack/JobActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyTrack/JobActionTest.java
@@ -76,12 +76,12 @@ class JobActionTest {
         final User anonymous = User.getOrCreateByIdOrFullName(ACL.ANONYMOUS_USERNAME);
         // without propper permissions
         try (ACLContext ignored = ACL.as(anonymous)) {
-            assertThatThrownBy(() -> uut.getSeverityDistributionTrend()).isInstanceOf(AccessDeniedException3.class);
+            assertThatThrownBy(uut::getSeverityDistributionTrend).isInstanceOf(AccessDeniedException3.class);
         }
         // with propper permissions
         try (ACLContext ignored = ACL.as(anonymous)) {
             mockAuthorizationStrategy.grant(Job.READ).onItems(project).to(anonymous);
-            assertThatCode(() -> uut.getSeverityDistributionTrend()).doesNotThrowAnyException();
+            assertThatCode(uut::getSeverityDistributionTrend).doesNotThrowAnyException();
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/DependencyTrack/ResultActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyTrack/ResultActionTest.java
@@ -77,12 +77,12 @@ class ResultActionTest {
         final User anonymous = User.getOrCreateByIdOrFullName(ACL.ANONYMOUS_USERNAME);
         // without propper permissions
         try (ACLContext ignored = ACL.as(anonymous)) {
-            assertThatThrownBy(() -> uut.getFindingsJson()).isInstanceOf(AccessDeniedException3.class);
+            assertThatThrownBy(uut::getFindingsJson).isInstanceOf(AccessDeniedException3.class);
         }
         // with propper permissions
         try (ACLContext ignored = ACL.as(anonymous)) {
             mockAuthorizationStrategy.grant(Job.READ).onItems(project).to(anonymous);
-            assertThatCode(() -> uut.getFindingsJson()).doesNotThrowAnyException();
+            assertThatCode(uut::getFindingsJson).doesNotThrowAnyException();
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/DependencyTrack/ViolationsJobActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyTrack/ViolationsJobActionTest.java
@@ -78,12 +78,12 @@ class ViolationsJobActionTest {
         final var anonymous = User.getOrCreateByIdOrFullName(ACL.ANONYMOUS_USERNAME);
         // without propper permissions
         try (ACLContext ignored = ACL.as(anonymous)) {
-            assertThatThrownBy(() -> uut.getViolationsTrend()).isInstanceOf(AccessDeniedException3.class);
+            assertThatThrownBy(uut::getViolationsTrend).isInstanceOf(AccessDeniedException3.class);
         }
         // with propper permissions
         try (ACLContext ignored = ACL.as(anonymous)) {
             mockAuthorizationStrategy.grant(Job.READ).onItems(project).to(anonymous);
-            assertThatCode(() -> uut.getViolationsTrend()).doesNotThrowAnyException();
+            assertThatCode(uut::getViolationsTrend).doesNotThrowAnyException();
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/DependencyTrack/ViolationsRunActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyTrack/ViolationsRunActionTest.java
@@ -76,12 +76,12 @@ class ViolationsRunActionTest {
         final User anonymous = User.getOrCreateByIdOrFullName(ACL.ANONYMOUS_USERNAME);
         // without propper permissions
         try (ACLContext ignored = ACL.as(anonymous)) {
-            assertThatThrownBy(() -> uut.getViolationsJson()).isInstanceOf(AccessDeniedException3.class);
+            assertThatThrownBy(uut::getViolationsJson).isInstanceOf(AccessDeniedException3.class);
         }
         // with propper permissions
         try (ACLContext ignored = ACL.as(anonymous)) {
             mockAuthorizationStrategy.grant(Job.READ).onItems(project).to(anonymous);
-            assertThatCode(() -> uut.getViolationsJson()).doesNotThrowAnyException();
+            assertThatCode(uut::getViolationsJson).doesNotThrowAnyException();
         }
     }
 


### PR DESCRIPTION
This adds support for Dependency-Track's `isLatest` flag, which was introduced in version [v4.12.0](https://docs.dependencytrack.org/changelog/#v4-12-0). **This is a breaking change as it requires Dependency-Track v4.12 or newer!**

closes #286
