### PR TITLE
chore(Jenkinsfile) enable Artifact Caching Proxy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 buildPlugin(
   forkCount: '1C',
   useContainerAgent: true,
-  useArtifactCachingProxy: false, // workaround for https://github.com/jenkins-infra/pipeline-library/issues/891
+  useArtifactCachingProxy: true,
   jdkVersions: [17],
   platforms: ['linux'],
 )


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4426#issuecomment-2821336331

This change enable again the artifact caching proxy ("ACP") system in ci.jenkins.io to keep lowering the usage on Artifactory (which is a major topic for the Jenkins infrastructure team).

Since I'm not a maintainer of this plugin, the PR check will use the `Jenkinsfile` of the main branch (as this change will be marked as "untrusted". 
Instead, I tested it with https://ci.jenkins.io/job/Plugins/job/dependency-track-plugin/job/master/333/ which is a replay of a `master` branch build with the same change as this PR: it was successful and used ACP.