### PR TITLE
refactoring: introduce "api" package

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/ApiClientFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/ApiClientFactory.java
@@ -15,6 +15,10 @@
  */
 package org.jenkinsci.plugins.DependencyTrack;
 
+import okhttp3.OkHttpClient;
+import org.jenkinsci.plugins.DependencyTrack.api.ApiClient;
+import org.jenkinsci.plugins.DependencyTrack.api.Logger;
+
 /**
  *
  * @author Ronny "Sephiroth" Perinke <sephiroth@sephiroth-j.de>
@@ -22,5 +26,5 @@ package org.jenkinsci.plugins.DependencyTrack;
 @FunctionalInterface
 interface ApiClientFactory {
 
-    ApiClient create(final String baseUrl, final String apiKey, final ConsoleLogger logger, final int connectionTimeout, final int readTimeout);
+    ApiClient create(final String baseUrl, final String apiKey, final Logger logger, final OkHttpClient httpClient);
 }

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/ConsoleLogger.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/ConsoleLogger.java
@@ -18,8 +18,9 @@ package org.jenkinsci.plugins.DependencyTrack;
 import hudson.console.LineTransformationOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import org.jenkinsci.plugins.DependencyTrack.api.Logger;
 
-public class ConsoleLogger extends LineTransformationOutputStream {
+class ConsoleLogger extends LineTransformationOutputStream implements Logger {
 
     private static final String PREFIX = "[DependencyTrack] ";
     private final PrintStream logger;
@@ -37,7 +38,8 @@ public class ConsoleLogger extends LineTransformationOutputStream {
      *
      * @param message The message to log
      */
-    protected void log(final String message) {
+    @Override
+    public void log(final String message) {
         logger.println(PREFIX + message.replace("\n", "\n" + PREFIX));
     }
 

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/PluginUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/PluginUtil.java
@@ -15,14 +15,17 @@
  */
 package org.jenkinsci.plugins.DependencyTrack;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.util.FormValidation;
+import io.jenkins.plugins.okhttp.api.JenkinsOkHttpClient;
+import jakarta.annotation.Nonnull;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.Collection;
 import lombok.experimental.UtilityClass;
+import okhttp3.OkHttpClient;
 import org.apache.commons.lang.StringUtils;
+import org.springframework.lang.Nullable;
 
 @UtilityClass
 class PluginUtil {
@@ -33,7 +36,7 @@ class PluginUtil {
      * @param value The value of the URL as specified in the global config
      * @return a FormValidation object
      */
-    @NonNull
+    @Nonnull
     static FormValidation doCheckUrl(@Nullable final String value) {
         if (value == null || value.isBlank()) {
             return FormValidation.ok();
@@ -63,7 +66,15 @@ class PluginUtil {
      * @return {@code true} if all elements are of type {@code type} (also if
      * coll is empty), else {@code false}
      */
-    static boolean areAllElementsOfType(@NonNull final Collection<?> coll, @NonNull final Class<?> type) {
+    static boolean areAllElementsOfType(@Nonnull final Collection<?> coll, @Nonnull final Class<?> type) {
         return coll.stream().allMatch(type::isInstance);
+    }
+
+    @Nonnull
+    static OkHttpClient newHttpClient(final int connectionTimeout, final int readTimeout) {
+        return JenkinsOkHttpClient.newClientBuilder(new OkHttpClient())
+                .connectTimeout(Duration.ofSeconds(connectionTimeout))
+                .readTimeout(Duration.ofSeconds(readTimeout))
+                .build();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/ProjectProperties.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/ProjectProperties.java
@@ -15,14 +15,14 @@
  */
 package org.jenkinsci.plugins.DependencyTrack;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
 import hudson.RelativePath;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.util.ListBoxModel;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
@@ -101,7 +101,7 @@ public final class ProjectProperties extends AbstractDescribableImpl<ProjectProp
     @Setter(onMethod_ = {@DataBoundSetter})
     private Boolean isLatest;
 
-    @NonNull
+    @Nonnull
     public List<String> getTags() {
         return normalizeTags(tags);
     }
@@ -122,15 +122,15 @@ public final class ProjectProperties extends AbstractDescribableImpl<ProjectProp
         }
     }
 
-    private void setTagsIntern(@NonNull final String value) {
+    private void setTagsIntern(@Nonnull final String value) {
         setTagsIntern(value.split("\\s+"));
     }
 
-    private void setTagsIntern(@NonNull final String[] values) {
+    private void setTagsIntern(@Nonnull final String[] values) {
         setTagsIntern(Stream.of(values).collect(Collectors.toSet()));
     }
 
-    private void setTagsIntern(@NonNull final Collection<String> values) {
+    private void setTagsIntern(@Nonnull final Collection<String> values) {
         tags = normalizeTags(values);
     }
 
@@ -164,12 +164,12 @@ public final class ProjectProperties extends AbstractDescribableImpl<ProjectProp
         this.parentVersion = StringUtils.trimToNull(parentVersion);
     }
 
-    @NonNull
+    @Nonnull
     public String getTagsAsText() {
         return StringUtils.join(getTags(), System.lineSeparator());
     }
 
-    @NonNull
+    @Nonnull
     private List<String> normalizeTags(final Collection<String> values) {
         return (values != null ? values.stream() : Stream.<String>empty())
                 .map(String::trim)

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/ResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/ResultAction.java
@@ -15,11 +15,11 @@
  */
 package org.jenkinsci.plugins.DependencyTrack;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Plugin;
 import hudson.PluginWrapper;
 import hudson.model.Action;
 import hudson.model.Run;
+import jakarta.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
@@ -94,7 +94,7 @@ public class ResultAction implements RunAction2, SimpleBuildStep.LastBuildAction
         return Set.of(new JobAction(run.getParent()));
     }
 
-    @NonNull
+    @Nonnull
     public String getVersionHash() {
         return DigestUtils.sha256Hex(
                 Optional.ofNullable(Jenkins.get().getPlugin("dependency-track"))

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/ViolationsRunAction.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/ViolationsRunAction.java
@@ -15,11 +15,11 @@
  */
 package org.jenkinsci.plugins.DependencyTrack;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Plugin;
 import hudson.PluginWrapper;
 import hudson.model.Action;
 import hudson.model.Run;
+import jakarta.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
@@ -92,7 +92,7 @@ public class ViolationsRunAction implements RunAction2, SimpleBuildStep.LastBuil
         return Set.of(new ViolationsJobAction(run.getParent()));
     }
 
-    @NonNull
+    @Nonnull
     public String getVersionHash() {
         return DigestUtils.sha256Hex(
                 Optional.ofNullable(Jenkins.get().getPlugin("dependency-track"))

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/api/ApiClientException.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/api/ApiClientException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2020 OWASP.
+ * This file is part of Dependency-Track Jenkins plugin.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,23 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jenkinsci.plugins.DependencyTrack.model;
+package org.jenkinsci.plugins.DependencyTrack.api;
 
-import lombok.Value;
+import java.io.IOException;
 
-@Value
-public class UploadResult {
+public class ApiClientException extends IOException {
 
-	private final boolean success;
-	private final String token;
+    public ApiClientException(String message) {
+        super(message);
+    }
 
-	public UploadResult(boolean success) {
-		this(success, null);
-	}
-
-	public UploadResult(boolean success, String token) {
-		this.success = success;
-		this.token = token;
-	}
+    public ApiClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/api/ApiClientExceptionClassifier.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/api/ApiClientExceptionClassifier.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jenkinsci.plugins.DependencyTrack;
+package org.jenkinsci.plugins.DependencyTrack.api;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/api/Logger.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/api/Logger.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of Dependency-Track Jenkins plugin.
+ * Copyright 2025 OWASP.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,18 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jenkinsci.plugins.DependencyTrack;
+package org.jenkinsci.plugins.DependencyTrack.api;
 
-import java.io.IOException;
+/**
+ *
+ * @author Ronny "Sephiroth" Perinke <sephiroth@sephiroth-j.de>
+ */
+@FunctionalInterface
+public interface Logger {
 
-public class ApiClientException extends IOException {
-
-    public ApiClientException(String message) {
-        super(message);
-    }
-
-    public ApiClientException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
+    void log(String msg);
 }

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/api/ProjectData.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/api/ProjectData.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 OWASP.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jenkinsci.plugins.DependencyTrack.api;
+
+import jakarta.annotation.Nullable;
+import java.util.List;
+
+/**
+ *
+ * @author Ronny "Sephiroth" Perinke <sephiroth@sephiroth-j.de>
+ */
+public final record ProjectData(@Nullable String id,
+        @Nullable String name,
+        @Nullable String version,
+        boolean autoCreate,
+        @Nullable Properties properties) {
+
+    public static final record Properties(
+            @Nullable List<String> tags,
+            @Nullable String swidTagId,
+            @Nullable String group,
+            @Nullable String description,
+            @Nullable String parentId,
+            @Nullable String parentName,
+            @Nullable String parentVersion,
+            @Nullable Boolean isLatest) {
+
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/api/UploadResult.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/api/UploadResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 OWASP.
+ * Copyright 2020 OWASP.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jenkinsci.plugins.DependencyTrack;
+package org.jenkinsci.plugins.DependencyTrack.api;
 
-import okhttp3.OkHttpClient;
+import jakarta.annotation.Nullable;
 
-/**
- *
- * @author Ronny "Sephiroth" Perinke <sephiroth@sephiroth-j.de>
- */
-@FunctionalInterface
-interface HttpClientFactory {
+public final record UploadResult(boolean success, @Nullable String token) {
 
-    OkHttpClient create();
+    public UploadResult(boolean success) {
+        this(success, null);
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/ComponentParser.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/ComponentParser.java
@@ -13,20 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jenkinsci.plugins.DependencyTrack;
+package org.jenkinsci.plugins.DependencyTrack.model;
 
 import lombok.experimental.UtilityClass;
 import net.sf.json.JSONObject;
-import org.jenkinsci.plugins.DependencyTrack.model.Component;
 
 /**
  *
  * @author Ronny "Sephiroth" Perinke <sephiroth@sephiroth-j.de>
  */
 @UtilityClass
-class ComponentParser extends ModelParser {
+public class ComponentParser extends ModelParser {
 
-    Component parseComponent(JSONObject json) {
+    public Component parseComponent(JSONObject json) {
         final String uuid = getKeyOrNull(json, "uuid");
         final String name = getKeyOrNull(json, "name");
         final String group = getKeyOrNull(json, "group");

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/Finding.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/Finding.java
@@ -15,7 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyTrack.model;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import jakarta.annotation.Nonnull;
 import java.io.Serializable;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -42,7 +42,7 @@ public class Finding implements Serializable {
      * {@link #component} as this one and this
      * {@link #vulnerability} {@link Vulnerability#isAliasOf(org.jenkinsci.plugins.DependencyTrack.model.Vulnerability) is an alias of the other one}
      */
-    public boolean isAliasOf(@NonNull final Finding other) {
+    public boolean isAliasOf(@Nonnull final Finding other) {
         return vulnerability != null && component.equals(other.component) && other.getVulnerability() != null && vulnerability.isAliasOf(other.getVulnerability());
     }
 
@@ -54,7 +54,7 @@ public class Finding implements Serializable {
      * {@link #component} as this one and this
      * {@link #vulnerability} {@link Vulnerability#hasAlias(org.jenkinsci.plugins.DependencyTrack.model.Vulnerability) has the others one's vulnerability as an alias}
      */
-    public boolean hasAlias(@NonNull final Finding alias) {
+    public boolean hasAlias(@Nonnull final Finding alias) {
         return vulnerability != null && component.equals(alias.component) && alias.getVulnerability() != null && vulnerability.hasAlias(alias.getVulnerability());
     }
 

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/FindingParser.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/FindingParser.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jenkinsci.plugins.DependencyTrack;
+package org.jenkinsci.plugins.DependencyTrack.model;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,16 +24,11 @@ import lombok.experimental.UtilityClass;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONNull;
 import net.sf.json.JSONObject;
-import org.jenkinsci.plugins.DependencyTrack.model.Analysis;
-import org.jenkinsci.plugins.DependencyTrack.model.Component;
-import org.jenkinsci.plugins.DependencyTrack.model.Finding;
-import org.jenkinsci.plugins.DependencyTrack.model.Severity;
-import org.jenkinsci.plugins.DependencyTrack.model.Vulnerability;
 
 @UtilityClass
-class FindingParser extends ModelParser {
+public class FindingParser extends ModelParser {
 
-    List<Finding> parse(final String jsonResponse) {
+    public List<Finding> parse(final String jsonResponse) {
         final JSONArray jsonArray = JSONArray.fromObject(jsonResponse);
         return jsonArray.stream()
                 .map(JSONObject.class::cast)

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/ModelParser.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/ModelParser.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jenkinsci.plugins.DependencyTrack;
+package org.jenkinsci.plugins.DependencyTrack.model;
 
 import java.util.Optional;
 import java.util.function.Predicate;

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/ProjectParser.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/ProjectParser.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jenkinsci.plugins.DependencyTrack;
+package org.jenkinsci.plugins.DependencyTrack.model;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,12 +21,11 @@ import lombok.experimental.UtilityClass;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.DependencyTrack.model.Project;
 
 @UtilityClass
-class ProjectParser extends ModelParser {
+public class ProjectParser extends ModelParser {
 
-    Project parse(final JSONObject json) {
+    public Project parse(final JSONObject json) {
         final String lastInheritedRiskScoreStr = getKeyOrNull(json, "lastInheritedRiskScore");
         final String activeStr = getKeyOrNull(json, "active");
         return Project.builder()

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/RiskGate.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/RiskGate.java
@@ -15,9 +15,9 @@
  */
 package org.jenkinsci.plugins.DependencyTrack.model;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.model.Result;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.io.Serializable;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +30,7 @@ public class RiskGate implements Serializable {
 
     private static final long serialVersionUID = 171256230735670985L;
 
-    @NonNull
+    @Nonnull
     private final Thresholds thresholds;
 
     /**
@@ -40,7 +40,7 @@ public class RiskGate implements Serializable {
      * @param previousDistribution previousDistribution
      * @return a Result
      */
-    public Result evaluate(@NonNull final SeverityDistribution currentDistribution, @Nullable final SeverityDistribution previousDistribution) {
+    public Result evaluate(@Nonnull final SeverityDistribution currentDistribution, @Nullable final SeverityDistribution previousDistribution) {
 
         Result result = Result.SUCCESS;
         if ((thresholds.totalFindings.failedCritical != null && currentDistribution.getCritical() > 0 && currentDistribution.getCritical() >= thresholds.totalFindings.failedCritical)

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/TeamParser.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/TeamParser.java
@@ -13,22 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jenkinsci.plugins.DependencyTrack;
+package org.jenkinsci.plugins.DependencyTrack.model;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import net.sf.json.JSONObject;
-import org.jenkinsci.plugins.DependencyTrack.model.Team;
 
 /**
  *
  * @author Ronny "Sephiroth" Perinke <sephiroth@sephiroth-j.de>
  */
 @UtilityClass
-class TeamParser {
+public class TeamParser {
 
-    Team parse(final JSONObject json) {
+    public Team parse(final JSONObject json) {
         final Set<String> permissions = json.getJSONArray("permissions").stream()
                 .map(JSONObject.class::cast)
                 .map(o -> o.getString("name"))

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/ViolationParser.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/ViolationParser.java
@@ -13,21 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jenkinsci.plugins.DependencyTrack;
+package org.jenkinsci.plugins.DependencyTrack.model;
 
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.jenkinsci.plugins.DependencyTrack.model.Violation;
-import org.jenkinsci.plugins.DependencyTrack.model.ViolationState;
-import org.jenkinsci.plugins.DependencyTrack.model.ViolationType;
 
 @UtilityClass
-class ViolationParser extends ModelParser {
+public class ViolationParser extends ModelParser {
 
-    List<Violation> parse(final String jsonResponse) {
+    public List<Violation> parse(final String jsonResponse) {
         final JSONArray jsonArray = JSONArray.fromObject(jsonResponse);
         return jsonArray.stream()
                 .map(JSONObject.class::cast)

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/Vulnerability.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/model/Vulnerability.java
@@ -15,8 +15,8 @@
  */
 package org.jenkinsci.plugins.DependencyTrack.model;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.io.Serializable;
 import java.util.List;
 import lombok.EqualsAndHashCode;
@@ -52,7 +52,7 @@ public class Vulnerability implements Serializable {
      * @return {@code true} if the {@code other} vulnerability contains this
      * vulnerability as an alias
      */
-    public boolean isAliasOf(@NonNull final Vulnerability other) {
+    public boolean isAliasOf(@Nonnull final Vulnerability other) {
         return other.aliases != null && other.aliases.contains(vulnId);
     }
 
@@ -63,7 +63,7 @@ public class Vulnerability implements Serializable {
      * @param alias the possible alias to check
      * @return {@code true} if this vulnerability contains the other as an alias
      */
-    public boolean hasAlias(@NonNull final Vulnerability alias) {
+    public boolean hasAlias(@Nonnull final Vulnerability alias) {
         return aliases != null && aliases.contains(alias.vulnId);
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/help-dependencyTrackPollingInterval_de.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher/help-dependencyTrackPollingInterval_de.html
@@ -1,3 +1,3 @@
 <div>
-    Legt die Anzahl der Sekunden fest, die zwischen zwei Prüfungen auf Beedingung der Analyse in Dependency-Track gewartet wird (Synchroner Veröffentlichungsmodus).
+    Legt die Anzahl der Sekunden fest, die zwischen zwei Prüfungen auf Beendingung der Analyse in Dependency-Track gewartet wird (Synchroner Veröffentlichungsmodus).
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages.properties
@@ -35,9 +35,6 @@ Builder.Result.ProjectIdMissing=The projectId has to be specified when auto crea
 Builder.Error.Projects=Unable to retrieve projects. Error was: {0}
 Builder.Error.Processing=An error occurred processing artifact "{0}". Error was: {1}
 Builder.Success=The artifact was successfully published. You may now navigate to {0} to view the results.
-Builder.Payload.Invalid=Invalid payload submitted to server
-Builder.Unauthorized=Unauthorized. Ensure a valid API key is specified.
-Builder.Project.NotFound=The specified project could not be found
 Builder.Polling=Polling Dependency-Track for BOM processing status
 Builder.Polling.Timeout.Exceeded=Polling Dependency-Track for results is taking longer than expected - polling limit exceeded
 Builder.Project.Lookup=Looking up id of newly created project with name "{0}" and version "{1}"
@@ -52,14 +49,6 @@ Builder.Threshold.NoComparison=This is the first build. Findings will not be com
 Builder.Threshold.NoSync=Warning: You have configured threshold values, but the synchronous publishing mode is disabled! The threshold values are not evaluated!
 Builder.Upload.Failed=Uploading artifact failed
 Builder.Connection.Failed=Could not connect to Dependency-Track. Please check the plugin configuration.
-
-ApiClient.Error.Connection=An error occurred connecting to Dependency-Track - HTTP response code: {0} {1}
-ApiClient.Error.TokenProcessing=An error occurred while checking if a token is being processed - HTTP response code: {0} {1}
-ApiClient.Error.RetrieveFindings=An error occurred while retrieving findings - HTTP response code: {0} {1}
-ApiClient.Error.RetrieveViolations=An error occurred while retrieving violations - HTTP response code: {0} {1}
-ApiClient.Error.ProjectLookup=An error occurred while looking up project id for name "{0}" and version "{1}" - HTTP response code: {2} {3}
-ApiClient.Error.ProjectLoad=An error occurred while loading project with id "{0}" - HTTP response code: {1} {2}
-ApiClient.Error.ProjectUpdate=An error occurred while updating project with id "{0}" - HTTP response code: {1} {2}
 
 Result.DT.Report=Report of Vulnerabilities
 Result.DT.ReportViolations=Report of Policy Violations

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages_de.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages_de.properties
@@ -35,9 +35,6 @@ Builder.Result.ProjectIdMissing=Eine Projekt-ID muss angegeben werden, wenn das 
 Builder.Error.Projects=Projekte konnten nicht ermittelt werden, der Fehler war: {0}
 Builder.Error.Processing=Es ist ein Fehler beim verarbeiten des Artefakts "{0}" aufgetreten. Der Fehler war: {1}
 Builder.Success=Das Artefakt wurde erfolgreich hochgeladen. Sie k\u00f6nnen nun {0} aufrufen, um die Ergebnisse anzusehen.
-Builder.Payload.Invalid=Ung\u00fcltiger Anfrage an Server gesendet
-Builder.Unauthorized=Nicht autorisiert! Bitte sicherstellen, dass ein g\u00fcltiger API-Schl\u00fcssel angegeben ist.
-Builder.Project.NotFound=Das angegebene Projekt wurde nicht gefunden!
 Builder.Polling=Warte auf Ende der Analyse in Dependency-Track
 Builder.Polling.Timeout.Exceeded=Wartezeit f\u00fcr die Analyseergebnisse \u00fcberschritten
 Builder.Project.Lookup=Ermittle ID des eben erzeugten Projekts mit Namen "{0}" und Version "{1}"
@@ -52,14 +49,6 @@ Builder.Threshold.NoComparison=Dies ist der erste Lauf. Die Ergebnisse werden ni
 Builder.Threshold.NoSync=Achtung: Sie haben Schwellenwerte konfiguriert, aber der synchrone Ver\u00f6ffentlichungsmodus ist deaktiviert! Die Schwellenwerte werden nicht ausgewertet!
 Builder.Upload.Failed=Hochladen des Artefakts fehlgeschlagen
 Builder.Connection.Failed=Es konnte keine Verbindung mit Dependency-Track hergestellt werden! Bitte pr\u00fcfen Sie die Plugin-Konfiguration.
-
-ApiClient.Error.Connection=Verbindungsfehler mit Dependency-Track - HTTP-Antwortcode: {0} {1}
-ApiClient.Error.TokenProcessing=Bei der Pr\u00fcfung, ob ein Token verarbeitet wird, ist ein Fehler aufgetreten - HTTP-Antwortcode: {0} {1}
-ApiClient.Error.RetrieveFindings=Beim Abrufen der Ergebnisse ist ein Fehler aufgetreten - HTTP-Antwortcode: {0} {1}
-ApiClient.Error.RetrieveViolations=Beim Abrufen der Richtlinienverst\u00f6\u00dfe ist ein Fehler aufgetreten - HTTP-Antwortcode: {0} {1}
-ApiClient.Error.ProjectLookup=Bei der Suche nach der Projekt-ID f\u00fcr Projektname "{0}" und Version "{1}" ist ein Fehler aufgetreten - HTTP-Antwortcode: {2} {3}
-ApiClient.Error.ProjectLoad=Bei dem Laden des Projekts mit ID "{0}" ist ein Fehler aufgetreten - HTTP response code: {1} {2}
-ApiClient.Error.ProjectUpdate=Bei der Aktualiserung des Projekts mit ID "{0}" ist ein Fehler aufgetreten - HTTP response code: {1} {2}
 
 Result.DT.Report=Report der Schwachstellen
 Result.DT.ReportViolations=Report der Richtlinienverst\u00f6\u00dfe

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/api/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/api/Messages.properties
@@ -1,0 +1,25 @@
+# This file is part of Dependency-Track Jenkins plugin.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ApiClient.Error.Connection=An error occurred connecting to Dependency-Track - HTTP response code: {0} {1}
+ApiClient.Error.TokenProcessing=An error occurred while checking if a token is being processed - HTTP response code: {0} {1}
+ApiClient.Error.RetrieveFindings=An error occurred while retrieving findings - HTTP response code: {0} {1}
+ApiClient.Error.RetrieveViolations=An error occurred while retrieving violations - HTTP response code: {0} {1}
+ApiClient.Error.ProjectLookup=An error occurred while looking up project id for name "{0}" and version "{1}" - HTTP response code: {2} {3}
+ApiClient.Error.ProjectLoad=An error occurred while loading project with id "{0}" - HTTP response code: {1} {2}
+ApiClient.Error.ProjectUpdate=An error occurred while updating project with id "{0}" - HTTP response code: {1} {2}
+
+ApiClient.Unauthorized=Unauthorized. Ensure a valid API key is specified.
+ApiClient.Payload.Invalid=Invalid payload submitted to server
+ApiClient.Project.NotFound=The specified project could not be found

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/api/Messages_de.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/api/Messages_de.properties
@@ -1,0 +1,25 @@
+# This file is part of Dependency-Track Jenkins plugin.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ApiClient.Error.Connection=Verbindungsfehler mit Dependency-Track - HTTP-Antwortcode: {0} {1}
+ApiClient.Error.TokenProcessing=Bei der Pr\u00fcfung, ob ein Token verarbeitet wird, ist ein Fehler aufgetreten - HTTP-Antwortcode: {0} {1}
+ApiClient.Error.RetrieveFindings=Beim Abrufen der Ergebnisse ist ein Fehler aufgetreten - HTTP-Antwortcode: {0} {1}
+ApiClient.Error.RetrieveViolations=Beim Abrufen der Richtlinienverst\u00f6\u00dfe ist ein Fehler aufgetreten - HTTP-Antwortcode: {0} {1}
+ApiClient.Error.ProjectLookup=Bei der Suche nach der Projekt-ID f\u00fcr Projektname "{0}" und Version "{1}" ist ein Fehler aufgetreten - HTTP-Antwortcode: {2} {3}
+ApiClient.Error.ProjectLoad=Bei dem Laden des Projekts mit ID "{0}" ist ein Fehler aufgetreten - HTTP response code: {1} {2}
+ApiClient.Error.ProjectUpdate=Bei der Aktualiserung des Projekts mit ID "{0}" ist ein Fehler aufgetreten - HTTP response code: {1} {2}
+
+ApiClient.Unauthorized=Nicht autorisiert! Bitte sicherstellen, dass ein g\u00fcltiger API-Schl\u00fcssel angegeben ist.
+ApiClient.Payload.Invalid=Ung\u00fcltiger Anfrage an Server gesendet
+ApiClient.Project.NotFound=Das angegebene Projekt wurde nicht gefunden!

--- a/src/test/java/org/jenkinsci/plugins/DependencyTrack/ResultActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyTrack/ResultActionTest.java
@@ -22,13 +22,10 @@ import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.security.AccessDeniedException3;
-import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import net.sf.json.JSONArray;
 import org.assertj.core.api.Assertions;
-import org.assertj.core.util.Files;
 import org.jenkinsci.plugins.DependencyTrack.model.Finding;
 import org.jenkinsci.plugins.DependencyTrack.model.SeverityDistribution;
 import org.junit.jupiter.api.Test;
@@ -46,11 +43,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 @WithJenkins
 class ResultActionTest {
-
-    private List<Finding> getTestFindings() {
-        File findings = new File("src/test/resources/findings.json");
-        return FindingParser.parse(Files.contentOf(findings, StandardCharsets.UTF_8));
-    }
+    private final List<Finding> testFindings = List.of(new Finding(null, null, null, ""));
 
     @Test
     void getVersionHashTest(JenkinsRule j) {
@@ -71,7 +64,7 @@ class ResultActionTest {
             project = j.createFreeStyleProject();
         }
         final FreeStyleBuild b1 = new FreeStyleBuild(project);
-        final ResultAction uut = new ResultAction(getTestFindings(), new SeverityDistribution(1));
+        final ResultAction uut = new ResultAction(testFindings, new SeverityDistribution(1));
         uut.onLoad(b1);
 
         final User anonymous = User.getOrCreateByIdOrFullName(ACL.ANONYMOUS_USERNAME);
@@ -91,15 +84,15 @@ class ResultActionTest {
     void getFindingsJson(JenkinsRule j) throws IOException {
         final FreeStyleProject project = j.createFreeStyleProject();
         final FreeStyleBuild b1 = new FreeStyleBuild(project);
-        final ResultAction uut = new ResultAction(getTestFindings(), new SeverityDistribution(1));
+        final ResultAction uut = new ResultAction(testFindings, new SeverityDistribution(1));
         uut.onLoad(b1);
-        Assertions.<JSONArray>assertThat(uut.getFindingsJson()).isEqualTo(JSONArray.fromObject(getTestFindings()));
+        Assertions.<JSONArray>assertThat(uut.getFindingsJson()).isEqualTo(JSONArray.fromObject(testFindings));
     }
 
     @Test
     void hasFindingsTest() {
         assertThat(new ResultAction(null, new SeverityDistribution(1)).hasFindings()).isFalse();
         assertThat(new ResultAction(List.of(), new SeverityDistribution(1)).hasFindings()).isFalse();
-        assertThat(new ResultAction(getTestFindings(), new SeverityDistribution(1)).hasFindings()).isTrue();
+        assertThat(new ResultAction(testFindings, new SeverityDistribution(1)).hasFindings()).isTrue();
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/DependencyTrack/ViolationsRunActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyTrack/ViolationsRunActionTest.java
@@ -22,14 +22,13 @@ import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.security.AccessDeniedException3;
-import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import net.sf.json.JSONArray;
 import org.assertj.core.api.Assertions;
-import org.assertj.core.util.Files;
 import org.jenkinsci.plugins.DependencyTrack.model.Violation;
+import org.jenkinsci.plugins.DependencyTrack.model.ViolationState;
+import org.jenkinsci.plugins.DependencyTrack.model.ViolationType;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
@@ -45,11 +44,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 @WithJenkins
 class ViolationsRunActionTest {
-
-    private List<Violation> getTestViolations() {
-        File violations = new File("src/test/resources/violations.json");
-        return ViolationParser.parse(Files.contentOf(violations, StandardCharsets.UTF_8));
-    }
+    private List<Violation> testViolations = List.of(new Violation("uuid", ViolationType.LICENSE, ViolationState.FAIL, "policyName", null));
 
     @Test
     void getVersionHashTest(JenkinsRule j) {
@@ -70,7 +65,7 @@ class ViolationsRunActionTest {
             project = j.createFreeStyleProject();
         }
         final FreeStyleBuild b1 = new FreeStyleBuild(project);
-        final ViolationsRunAction uut = new ViolationsRunAction(getTestViolations());
+        final ViolationsRunAction uut = new ViolationsRunAction(testViolations);
         uut.onLoad(b1);
 
         final User anonymous = User.getOrCreateByIdOrFullName(ACL.ANONYMOUS_USERNAME);
@@ -90,7 +85,7 @@ class ViolationsRunActionTest {
     void getViolationsJson(JenkinsRule j) throws IOException {
         final FreeStyleProject project = j.createFreeStyleProject();
         final FreeStyleBuild b1 = new FreeStyleBuild(project);
-        final List<Violation> violations = getTestViolations();
+        final List<Violation> violations = testViolations;
         final ViolationsRunAction uut = new ViolationsRunAction(violations);
         uut.onLoad(b1);
         Assertions.<JSONArray>assertThat(uut.getViolationsJson()).isEqualTo(JSONArray.fromObject(violations));
@@ -100,6 +95,6 @@ class ViolationsRunActionTest {
     void hasViolationsTest() {
         assertThat(new ViolationsRunAction(null).hasViolations()).isFalse();
         assertThat(new ViolationsRunAction(List.of()).hasViolations()).isFalse();
-        assertThat(new ViolationsRunAction(getTestViolations()).hasViolations()).isTrue();
+        assertThat(new ViolationsRunAction(testViolations).hasViolations()).isTrue();
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/DependencyTrack/model/FindingParserTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyTrack/model/FindingParserTest.java
@@ -13,17 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jenkinsci.plugins.DependencyTrack;
+package org.jenkinsci.plugins.DependencyTrack.model;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.assertj.core.util.Files;
-import org.jenkinsci.plugins.DependencyTrack.model.Analysis;
-import org.jenkinsci.plugins.DependencyTrack.model.Component;
-import org.jenkinsci.plugins.DependencyTrack.model.Finding;
-import org.jenkinsci.plugins.DependencyTrack.model.Severity;
-import org.jenkinsci.plugins.DependencyTrack.model.Vulnerability;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/org/jenkinsci/plugins/DependencyTrack/model/ViolationParserTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyTrack/model/ViolationParserTest.java
@@ -13,15 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jenkinsci.plugins.DependencyTrack;
+package org.jenkinsci.plugins.DependencyTrack.model;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import org.assertj.core.util.Files;
-import org.jenkinsci.plugins.DependencyTrack.model.Component;
-import org.jenkinsci.plugins.DependencyTrack.model.Violation;
-import org.jenkinsci.plugins.DependencyTrack.model.ViolationState;
-import org.jenkinsci.plugins.DependencyTrack.model.ViolationType;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
keep jenkins-specific things outside of sub-package like "api" and "model"
