### PR TITLE
revert to `FilePath.read`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### 🐞 Bugs Fixed
 - The list of projects in the select box did not show all available projects.
 - Policy violations were limited to 100 ([#345](https://github.com/jenkinsci/dependency-track-plugin/issues/345))
+- The publishing step may get stuck when reading the BOM ([#336](https://github.com/jenkinsci/dependency-track-plugin/issues/336))
 
 ## v6.0.1 - 2025-03-23
 ### ⚠ Breaking

--- a/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyTrack/DependencyTrackPublisher.java
@@ -30,6 +30,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Optional;
 import jenkins.tasks.SimpleBuildStep;
@@ -322,8 +323,9 @@ public final class DependencyTrackPublisher extends Recorder implements SimpleBu
         }
 
         String bom = null;
-        try {
-            bom = artifactFilePath.readToString();
+        logger.log(Messages.Builder_Artifact_Reading(effectiveArtifact));
+        try (var in = artifactFilePath.read()) {
+            bom = new String(in.readAllBytes(), Charset.defaultCharset());
         } catch (IOException | InterruptedException e) {
             var msg = Messages.Builder_Error_Processing(effectiveArtifact, e.getLocalizedMessage());
             log.warn(msg, e);

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages.properties
@@ -30,6 +30,7 @@ Publisher.PermissionTest.Optional=<q>{0}</q> - optional
 Builder.Publishing=Publishing artifact "{1}" to Dependency-Track - {0}
 Builder.Artifact.NonExist=The specified artifact "{0}" does not exist
 Builder.Artifact.Unspecified=An artifact was not specified
+Builder.Artifact.Reading=Reading artifact "{0}"
 Builder.Result.InvalidArguments=Either the projectId or the projectName and projectVersion have to be specified
 Builder.Result.ProjectIdMissing=The projectId has to be specified when auto create projects is not enabled
 Builder.Error.Projects=Unable to retrieve projects. Error was: {0}

--- a/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages_de.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyTrack/Messages_de.properties
@@ -30,6 +30,7 @@ Publisher.PermissionTest.Optional=<q>{0}</q> - optional
 Builder.Publishing=Hochladen von Artefakt "{1}" in Dependency-Track - {0}
 Builder.Artifact.NonExist=Das angegebene Artefakt "{0}" wurde nicht gefunden!
 Builder.Artifact.Unspecified=Es wurde kein Artefakt angegeben!
+Builder.Artifact.Reading=Lese Artefakt "{0}"
 Builder.Result.InvalidArguments=Es m\u00fcssen entweder eine Projekt-ID oder ein Projektname zusammen mit einer Version angegeben werden!
 Builder.Result.ProjectIdMissing=Eine Projekt-ID muss angegeben werden, wenn das automatische Anlegen von Projekten nicht aktiviert ist!
 Builder.Error.Projects=Projekte konnten nicht ermittelt werden, der Fehler war: {0}


### PR DESCRIPTION
It seems that `FilePath.readToString` (used since https://github.com/jenkinsci/dependency-track-plugin/commit/e9c99bf162b60d09e270c091d92717e6aa502080) is the culprit and `FilePath.read` is the variant with better/broader compatibility.

fixes #336
